### PR TITLE
Fix ParsedExpression.ToString() for case of small decimal.

### DIFF
--- a/src/NCalc/Domain/SerializationVisitor.cs
+++ b/src/NCalc/Domain/SerializationVisitor.cs
@@ -149,7 +149,7 @@ namespace NCalc.Domain
                     break;
 
                 case ValueType.Float:
-                    Result.Append(decimal.Parse(expression.Value.ToString()).ToString(_numberFormatInfo)).Append(" ");
+                    Result.Append(decimal.Parse(expression.Value.ToString(), NumberStyles.Any).ToString(_numberFormatInfo)).Append(" ");
                     break;
 
                 case ValueType.Integer:

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -44,6 +44,16 @@ namespace NCalc.Tests
         }
 
         [Fact]
+        public void ParsedExpressionToStringShouldHandleSmallDecimals()
+        {
+            // small decimals starting with 0 resulting in scientific notation did not work in original NCalc
+            var equation = "0.000001";
+            var testExpression = new Expression(equation);
+            testExpression.Evaluate();
+            Assert.Equal(equation, testExpression.ParsedExpression.ToString());
+        }
+
+        [Fact]
         public void ShouldHandleUnicode()
         {
             Assert.Equal("経済協力開発機構", new Expression("'経済協力開発機構'").Evaluate());


### PR DESCRIPTION
There was a problem with the ParsedExpression.ToString() when the expression contained a small decimal number which gets converted to scientific notation.