### PR TITLE
Add support for evaluating the Abs() function using a double instead of a decimal

### DIFF
--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -299,9 +299,19 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Abs() takes exactly 1 argument");
 
-                    Result = Math.Abs(Convert.ToDecimal(
-                        Evaluate(function.Expressions[0]))
+                    bool useDouble = (_options & EvaluateOptions.UseDoubleForAbsFunction) == EvaluateOptions.UseDoubleForAbsFunction;
+                    if (useDouble)
+                    {
+                        Result = Math.Abs(Convert.ToDouble(
+                                                  Evaluate(function.Expressions[0]))
                         );
+                    }
+                    else
+                    {
+                        Result = Math.Abs(Convert.ToDecimal(
+                                                  Evaluate(function.Expressions[0]))
+                        );
+                    }
 
                     break;
 

--- a/src/NCalc/EvaluationOption.cs
+++ b/src/NCalc/EvaluationOption.cs
@@ -42,6 +42,11 @@ namespace NCalc
         /// <summary>
         ///     Allow calculation with boolean values.
         /// </summary>
-        BooleanCalculation = 1 << 8
+        BooleanCalculation = 1 << 8,
+
+        /// <summary>
+        ///     When using Abs(), return a double instead of a decimal.
+        /// </summary>
+        UseDoubleForAbsFunction = 1 << 9
     }
 }


### PR DESCRIPTION
Add an additional flag to `EvaluationOption `to make `Abs()` evaluation use `Math.Abs(double value)` instead of `Math.Abs(decimal value)`. This prevents an `InvalidOperationException `being thrown when a nested expression uses constant values alongside the `Abs()` function e.g. `Abs([a])/1.1` would throw because the left will be a `decimal `and the right a `double`.

This leaves the existing functionality unchanged unless when creating the expression you provide the option flag using the following syntax:
```csharp
Expression expression = new Expression("Abs([a])/1.1", EvaluateOptions.UseDoubleForAbsFunction)
expression.Parameters.Add("a", 5);
object value = expression.Evaluate();
```
