### PR TITLE
Allow value type contexts

### DIFF
--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -210,7 +210,7 @@ namespace NCalc
             return lambda.Compile();
         }
 
-        public Func<TContext, TResult> ToLambda<TContext, TResult>() where TContext : class
+        public Func<TContext, TResult> ToLambda<TContext, TResult>()
         {
             if (HasErrors())
             {

--- a/test/NCalc.Tests/Lambdas.cs
+++ b/test/NCalc.Tests/Lambdas.cs
@@ -285,5 +285,26 @@ namespace NCalc.Tests
             var sut = expression.ToLambda<object>();
             Assert.Equal(expected, sut());
         }
+
+        [Fact]
+        public void ShouldAllowValueTypeContexts()
+        {
+            // Arrange
+            const decimal expected = 6.908m;
+            var expression = new Expression("Foo * 3.14");
+            var sut = expression.ToLambda<FooStruct, decimal>();
+            var context = new FooStruct();
+
+            // Act
+            var actual = sut(context);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        internal struct FooStruct
+        {
+            public double Foo => 2.2;
+        }
     }
 }


### PR DESCRIPTION
This PR removes the restriction where `TContext` must be a reference type, which I think is unnecessarily restrictive.

The caller of `ToLambda` should bear the responsibility of understanding the performance characteristics of using a reference type vs a value type.