### PR TITLE
Support implicit conversion for primitive types.

### DIFF
--- a/src/NCalc/ExtendedMethodInfo.cs
+++ b/src/NCalc/ExtendedMethodInfo.cs
@@ -7,6 +7,6 @@ namespace NCalc
     {
         public MethodInfo BaseMethodInfo { get; set; }
         public L.Expression[] PreparedArguments { get; set; }
-
+        public int Score { get; set; }
     }
 }

--- a/test/NCalc.Tests/Lambdas.cs
+++ b/test/NCalc.Tests/Lambdas.cs
@@ -28,6 +28,11 @@ namespace NCalc.Tests
                 return a + b + c;
             }
 
+            public double Test(double a, double b, double c) 
+            {
+                return a + b + c;
+            }
+
             public string Sum(string msg, params int[] numbers) {
                 int total = 0;
                 foreach (var num in numbers) {
@@ -207,6 +212,17 @@ namespace NCalc.Tests
             Assert.Equal(5, lambda2(context));
             Assert.Equal(10, lambda3(context));
             Assert.Equal(400, lambda4(context));
+        }
+
+        [Theory]
+        [InlineData("Test(1, 1, 1)")]
+        [InlineData("Test(1.0, 1.0, 1.0)")]
+        [InlineData("Test(1.0, 1, 1.0)")]
+        public void ShouldHandleImplicitConversion(string input) {
+            var lambda = new Expression(input).ToLambda<Context, int>();
+
+            var context = new Context();
+            Assert.Equal(3, lambda(context));
         }
 
         [Fact]


### PR DESCRIPTION
resolves #51

* This only deals with primitive types using the [conversion table from microsoft](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/numeric-conversions#implicit-numeric-conversions). It does **not** fix issue #37 as `BigInteger` is not a primitive, nevertheless it does lay the ground work for it if someone wants to take it on.
* The implementation does not use the complex comparison defined by the csharp language specification in section _"7.4.3.4 Better conversion from type"_ ([online version](http://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/expressions#better-conversion-target)). Instead, it uses a simplified approach where for every implicit conversion performed, `memberFunctionScore` is incremented by one. The function with the lowest score is chosen. (A score of 0 indicates a perfect match between supplied arguments and candidate function parameters.)
* I removed `paramsMatchArguments` because it is not required (and keeping it introduces a bug with this implementation).
* I am not too sure of this approach so all aspects of this PR are open to suggestions.

Thanks for the speedy review of the inheritance issue btw, hopefully it'll be a while before you see another PR from me! :)