### PR TITLE
Prioritise lambda context methods over built in ones.

### DIFF
--- a/src/NCalc/LambdaExpressionVistor.cs
+++ b/src/NCalc/LambdaExpressionVistor.cs
@@ -188,7 +188,7 @@ namespace NCalc
                 return;
             }
 
-            //Context methods take prcedence over built-in functions because they're user-customisable.
+            //Context methods take precedence over built-in functions because they're user-customisable.
             var mi = FindMethod(function.Identifier.Name, args);
             if (mi != null) {
                 _result = L.Expression.Call(_context, mi.BaseMethodInfo, mi.PreparedArguments);

--- a/src/NCalc/LambdaExpressionVistor.cs
+++ b/src/NCalc/LambdaExpressionVistor.cs
@@ -168,45 +168,52 @@ namespace NCalc
                 args[i] = _result;
             }
 
-            switch (function.Identifier.Name.ToLowerInvariant())
-            {
-                case "if":
-                    var numberTypePriority = new Type[] { typeof(double), typeof(float), typeof(long), typeof(int), typeof(short) };
-                    var index1 = Array.IndexOf(numberTypePriority, args[1].Type);
-                    var index2 = Array.IndexOf(numberTypePriority, args[2].Type);
-                    if (index1 >= 0 && index2 >= 0 && index1 != index2)
-                    {
-                        args[1] = L.Expression.Convert(args[1], numberTypePriority[Math.Min(index1, index2)]);
-                        args[2] = L.Expression.Convert(args[2], numberTypePriority[Math.Min(index1, index2)]);
-                    }
-                    _result = L.Expression.Condition(args[0], args[1], args[2]);
-                    break;
-                case "in":
-                    var items = L.Expression.NewArrayInit(args[0].Type,
+            string functionName = function.Identifier.Name.ToLowerInvariant();
+            if (functionName == "if") {
+                var numberTypePriority = new Type[] { typeof(double), typeof(float), typeof(long), typeof(int), typeof(short) };
+                var index1 = Array.IndexOf(numberTypePriority, args[1].Type);
+                var index2 = Array.IndexOf(numberTypePriority, args[2].Type);
+                if (index1 >= 0 && index2 >= 0 && index1 != index2) {
+                    args[1] = L.Expression.Convert(args[1], numberTypePriority[Math.Min(index1, index2)]);
+                    args[2] = L.Expression.Convert(args[2], numberTypePriority[Math.Min(index1, index2)]);
+                }
+                _result = L.Expression.Condition(args[0], args[1], args[2]);
+                return;
+            } else if (functionName == "in") {
+                var items = L.Expression.NewArrayInit(args[0].Type,
                         new ArraySegment<L.Expression>(args, 1, args.Length - 1));
-                    var smi = typeof (Array).GetRuntimeMethod("IndexOf", new[] { typeof(Array), typeof(object) });
-                    var r = L.Expression.Call(smi, L.Expression.Convert(items, typeof(Array)), L.Expression.Convert(args[0], typeof(object)));
-                    _result = L.Expression.GreaterThanOrEqual(r, L.Expression.Constant(0));
-                    break;
+                var smi = typeof(Array).GetRuntimeMethod("IndexOf", new[] { typeof(Array), typeof(object) });
+                var r = L.Expression.Call(smi, L.Expression.Convert(items, typeof(Array)), L.Expression.Convert(args[0], typeof(object)));
+                _result = L.Expression.GreaterThanOrEqual(r, L.Expression.Constant(0));
+                return;
+            }
+
+            //Context methods take prcedence over built-in functions because they're user-customisable.
+            var mi = FindMethod(function.Identifier.Name, args);
+            if (mi != null) {
+                _result = L.Expression.Call(_context, mi.BaseMethodInfo, mi.PreparedArguments);
+                return;
+            }
+
+            switch (functionName)
+            {
                 case "min":
-                    var min_arg0 = L.Expression.Convert(args[0], typeof(double));
-                    var min_arg1 = L.Expression.Convert(args[1], typeof(double));
-                    _result = L.Expression.Condition(L.Expression.LessThan(min_arg0, min_arg1), min_arg0, min_arg1);
+                    var minArg0 = L.Expression.Convert(args[0], typeof(double));
+                    var minArg1 = L.Expression.Convert(args[1], typeof(double));
+                    _result = L.Expression.Condition(L.Expression.LessThan(minArg0, minArg1), minArg0, minArg1);
                     break;
                 case "max":
-                    var max_arg0 = L.Expression.Convert(args[0], typeof(double));
-                    var max_arg1 = L.Expression.Convert(args[1], typeof(double));
-                    _result = L.Expression.Condition(L.Expression.GreaterThan(max_arg0, max_arg1), max_arg0, max_arg1);
+                    var maxArg0 = L.Expression.Convert(args[0], typeof(double));
+                    var maxArg1 = L.Expression.Convert(args[1], typeof(double));
+                    _result = L.Expression.Condition(L.Expression.GreaterThan(maxArg0, maxArg1), maxArg0, maxArg1);
                     break;
                 case "pow":
-                    var pow_arg0 = L.Expression.Convert(args[0], typeof(double));
-                    var pow_arg1 = L.Expression.Convert(args[1], typeof(double));
-                    _result = L.Expression.Power(pow_arg0, pow_arg1);
+                    var powArg0 = L.Expression.Convert(args[0], typeof(double));
+                    var powArg1 = L.Expression.Convert(args[1], typeof(double));
+                    _result = L.Expression.Power(powArg0, powArg1);
                     break;
                 default:
-                    var mi = FindMethod(function.Identifier.Name, args);
-                    _result = L.Expression.Call(_context, mi.BaseMethodInfo, mi.PreparedArguments);
-                    break;
+                    throw new MissingMethodException($"method not found: {functionName}");
             }
         }
 
@@ -224,6 +231,8 @@ namespace NCalc
 
         private ExtendedMethodInfo FindMethod(string methodName, L.Expression[] methodArgs) 
         {
+            if (_context == null) return null;
+
             TypeInfo contextTypeInfo = _context.Type.GetTypeInfo();
             TypeInfo objectTypeInfo = typeof(object).GetTypeInfo();
             do 
@@ -247,7 +256,7 @@ namespace NCalc
                 if (candidates.Any()) return candidates.OrderBy(method => method.Score).First();
                 contextTypeInfo = contextTypeInfo.BaseType.GetTypeInfo();
             } while (contextTypeInfo != objectTypeInfo);
-            throw new MissingMethodException($"method not found: {methodName}");
+            return null;
         }
 
         /// <summary>

--- a/test/NCalc.Tests/Lambdas.cs
+++ b/test/NCalc.Tests/Lambdas.cs
@@ -70,6 +70,14 @@ namespace NCalc.Tests
                 return obj1.Count2 + obj2.Count2;
             }
 
+            public double Max(TestObject1 obj1, TestObject1 obj2) {
+                return Math.Max(obj1.Count1, obj2.Count1);
+            }
+
+            public double Min(TestObject1 obj1, TestObject1 obj2) {
+                return Math.Min(obj1.Count1, obj2.Count1);
+            }
+
             public class TestObject1
             {
                 public int Count1 { get; set; }
@@ -279,6 +287,19 @@ namespace NCalc.Tests
             var expression = new Expression(input);
             var sut = expression.ToLambda<bool>();
             Assert.True(sut());
+        }
+
+        [Theory]
+        [InlineData("Min(CreateTestObject1(1), CreateTestObject1(2))", 1)]
+        [InlineData("Max(CreateTestObject1(1), CreateTestObject1(2))", 2)]
+        [InlineData("Min(1, 2)", 1)]
+        [InlineData("Max(1, 2)", 2)]
+        public void ShouldProritiseContextFunctions(string input, double expected) {
+            var expression = new Expression(input);
+            var lambda = expression.ToLambda<Context, double>();
+            var context = new Context();
+            var actual = lambda(context);
+            Assert.Equal(expected, actual);
         }
 
         [Theory]


### PR DESCRIPTION
Closes #63 

* `Visit(Function function)` will now try to evaluate `function` in the following order:
  * (1) `if` and `in`.
  * (2) Functions defined in the `_context` (if context is provided).
  * (3) Built-in functions such as `Min`, `Max` and `Pow`.
  * (4) throws an exception if none of the above matches.
* `FindMethod` will now return `null` instead of throwing an exception.
* There are tests to assert that ncalc will fall back to built-in functions if a context doesn't have the specified method. (or if the context does have the function, but there is no valid overload for the arguments provided).