### PR TITLE
Remove TRACE constant defined by default in Release mode

### DIFF
--- a/src/NCalc/NCalc.csproj
+++ b/src/NCalc/NCalc.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>This is a port of NCalc for .NET Core applications.</Description>
@@ -25,6 +25,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DefineConstants />
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
@@ -33,8 +37,8 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The performance issue with TRACE constant was already discussed in ncalc project here: https://github.com/ncalc/ncalc/issues/51
This constant should be defined only in Debug mode, no need for Release configuration.