### PR TITLE
Fix for exponential argument evaluation when using nulls

### DIFF
--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -121,24 +121,28 @@ namespace NCalc.Domain
         {
             // simulate Lazy<Func<>> behavior for late evaluation
             object leftValue = null;
+            bool leftEvaluated = false;
             Func<object> left = () =>
                                  {
-                                     if (leftValue == null)
+                                     if (!leftEvaluated)
                                      {
                                          expression.LeftExpression.Accept(this);
                                          leftValue = Result;
+                                         leftEvaluated = true;
                                      }
                                      return leftValue;
                                  };
 
             // simulate Lazy<Func<>> behavior for late evaluation
             object rightValue = null;
+            bool rightEvaluated = false;
             Func<object> right = () =>
             {
-                if (rightValue == null)
+                if (!rightEvaluated)
                 {
                     expression.RightExpression.Accept(this);
                     rightValue = Result;
+                    rightEvaluated = true;
                 }
                 return rightValue;
             };

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using System.Linq;
 
 namespace NCalc.Tests
 {
@@ -124,6 +125,36 @@ namespace NCalc.Tests
 
             Assert.Throws<NullReferenceException>(() => e.Evaluate());
         }
+
+        [Fact]
+        public void ShouldEvaluateExcessiveNulls()
+        {
+            var e = new Expression(GetNullsFormula(), EvaluateOptions.AllowNullParameter);
+
+            Assert.Null(e.Evaluate());
+        }
+
+        [Fact]
+        public void ShouldEvaluateExcessiveNullsInReasonableTime()
+        {
+            var stopwatch = new System.Diagnostics.Stopwatch();
+            stopwatch.Start();
+
+            const int iterations = 1000;
+            var formula = GetNullsFormula();
+
+            for(int i = 0; i < iterations; i++)
+            {
+                new Expression(formula, EvaluateOptions.AllowNullParameter).Evaluate();
+            }
+
+            stopwatch.Stop();
+
+            const int targetMilliseconds = 100;
+            Assert.True((stopwatch.ElapsedMilliseconds / iterations ) <= targetMilliseconds, "Evaluation did not meet performance expectations");
+        }
+
+        private static string GetNullsFormula(int number = 100, string op = "+") => string.Join(op, Enumerable.Repeat("null", number));
 
         [Fact]
         public void ShouldParseValues()


### PR DESCRIPTION
It looks like there is an exponential increase in time complexity when evaluating arguments with a null value.  For n terms, the first term is evaluated 2<sup>n-1</sup> times, the second term is evaluated 2<sup>n-2</sup> times, and so on.

This appears to be caused by the Visit(BinaryExpression) method which uses null as a sentinel value to indicate whether the left or right side has already been lazily evaluated.  This change adds two booleans to track whether the halves have been visited.

This PR addresses #60, I've ensured all unit tests pass, and added additional tests to ensure nulls are evaluated as expected and within a reasonable time period. 