### PR TITLE
EvaluationVisitor.Result setter should be protected, not private.

### DIFF
--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -19,7 +19,7 @@ namespace NCalc.Domain
             _options = options;
         }
 
-        public object Result { get; private set; }
+        public object Result { get; protected set; }
 
         private object Evaluate(LogicalExpression expression)
         {


### PR DESCRIPTION
This is a backport of https://github.com/ncalc/ncalc/issues/79 
The setter should be protected to access it from derived class