### PR TITLE
Add parameterless constructor to ValueExpression

### DIFF
--- a/src/NCalc/Domain/Value.cs
+++ b/src/NCalc/Domain/Value.cs
@@ -5,6 +5,9 @@ namespace NCalc.Domain
 {
 	public class ValueExpression : LogicalExpression
 	{
+
+ 	public ValueExpression() {}
+  
         public ValueExpression(object value, ValueType type)
         {
             Value = value;


### PR DESCRIPTION
This is a backport from https://github.com/ncalc/ncalc/pull/61

Adding parameterless constructor will allow to serialize ValueExpression class