### PR TITLE
Fix code analysys warnings & culture support

### DIFF
--- a/grammer/NCalc.g
+++ b/grammer/NCalc.g
@@ -31,7 +31,7 @@ private string extractString(string text) {
             case 't': sb.Remove(slashIndex, 2).Insert(slashIndex, '\t'); break;
             case '\'': sb.Remove(slashIndex, 2).Insert(slashIndex, '\''); break;
             case '\\': sb.Remove(slashIndex, 2).Insert(slashIndex, '\\'); break;
-            default: throw new RecognitionException(null, CharStreams.fromString("Unvalid escape sequence: \\" + escapeType));
+            default: throw new RecognitionException(null, CharStreams.fromString("Invalid escape sequence: \\" + escapeType));
         }
 
         startIndex = slashIndex + 1;

--- a/src/NCalc/Domain/BinaryExpression.cs
+++ b/src/NCalc/Domain/BinaryExpression.cs
@@ -1,40 +1,40 @@
 namespace NCalc.Domain
 {
-	public class BinaryExpression : LogicalExpression
-	{
-		public BinaryExpression(BinaryExpressionType type, LogicalExpression leftExpression, LogicalExpression rightExpression)
-		{
+    public class BinaryExpression : LogicalExpression
+    {
+        public BinaryExpression(BinaryExpressionType type, LogicalExpression leftExpression, LogicalExpression rightExpression)
+        {
             Type = type;
             LeftExpression = leftExpression;
             RightExpression = rightExpression;
-		}
+        }
 
-	    public LogicalExpression LeftExpression { get; set; }
+        public LogicalExpression LeftExpression { get; set; }
 
-	    public LogicalExpression RightExpression { get; set; }
+        public LogicalExpression RightExpression { get; set; }
 
-	    public BinaryExpressionType Type { get; set; }
+        public BinaryExpressionType Type { get; set; }
 
-	    public override void Accept(LogicalExpressionVisitor visitor)
+        public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
         }
     }
 
-	public enum BinaryExpressionType
-	{
-		And,
-		Or,
-		NotEqual,
-		LesserOrEqual,
-		GreaterOrEqual,
-		Lesser,
-		Greater,
-		Equal,
-		Minus,
-		Plus,
-		Modulo,
-		Div,
+    public enum BinaryExpressionType
+    {
+        And,
+        Or,
+        NotEqual,
+        LesserOrEqual,
+        GreaterOrEqual,
+        Lesser,
+        Greater,
+        Equal,
+        Minus,
+        Plus,
+        Modulo,
+        Div,
         Times,
         BitwiseOr,
         BitwiseAnd,
@@ -42,5 +42,5 @@ namespace NCalc.Domain
         LeftShift,
         RightShift,
         Unknown
-	}
+    }
 }

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -10,6 +10,7 @@ namespace NCalc.Domain
 
         private readonly EvaluateOptions _options = EvaluateOptions.None;
         private readonly CultureInfo _cultureInfo = CultureInfo.CurrentCulture;
+        private readonly StringComparer _comparer;
 
         private bool IgnoreCase { get { return (_options & EvaluateOptions.IgnoreCase) == EvaluateOptions.IgnoreCase; } }
         private bool Ordinal { get { return (_options & EvaluateOptions.MatchStringsOrdinal) == EvaluateOptions.MatchStringsOrdinal; } }
@@ -22,6 +23,11 @@ namespace NCalc.Domain
         {
             _options = options;
             _cultureInfo = cultureInfo;
+
+            if (Ordinal)
+                _comparer = IgnoreCaseString ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            else
+                _comparer = StringComparer.Create(_cultureInfo, IgnoreCaseString);
         }
 
         public object Result { get; protected set; }
@@ -78,14 +84,7 @@ namespace NCalc.Domain
             b = Convert.ChangeType(b, mpt, _cultureInfo);
 
             if (mpt.Equals(typeof(string)) && (Ordinal || IgnoreCaseString))
-            {
-                if (Ordinal)
-                {
-                    if (IgnoreCaseString) return StringComparer.OrdinalIgnoreCase.Compare(a?.ToString(), b?.ToString());
-                    else StringComparer.Ordinal.Compare(a?.ToString(), b?.ToString());
-                }
-                else return StringComparer.CurrentCultureIgnoreCase.Compare(a?.ToString(), b?.ToString());
-            }
+                return _comparer.Compare(a?.ToString(), b?.ToString());
 
             if (ReferenceEquals(a, b))
             {

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -168,7 +168,7 @@ namespace NCalc.Domain
                     // (since anything between 1 and 0 is not int and 0 is an exception anyway
                     Result = IsReal(left()) || IsReal(right())
                                  ? Numbers.Divide(left(), right(), _options, _cultureInfo)
-                                 : Numbers.Divide(left(), right(), _options, _cultureInfo);
+                                 : Numbers.Divide(Convert.ToDouble(left()), right(), _options, _cultureInfo);
                     break;
 
                 case BinaryExpressionType.Equal:

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -296,7 +296,7 @@ namespace NCalc.Domain
             // Evaluating every value could produce unexpected behaviour
             for (int i = 0; i < function.Expressions.Length; i++)
             {
-                args.Parameters[i] = new Expression(function.Expressions[i], _options);
+                args.Parameters[i] = new Expression(function.Expressions[i], _options, _cultureInfo);
                 args.Parameters[i].EvaluateFunction += EvaluateFunction;
                 args.Parameters[i].EvaluateParameter += EvaluateParameter;
 

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -696,14 +696,12 @@ namespace NCalc.Domain
 
         public override void Visit(Identifier parameter)
         {
+            // The parameter is defined in the hashtable
             if (Parameters.TryGetValue(parameter.Name, out object value))
             {
-                // The parameter is defined in the hashtable
-                if (value is Expression)
+                // The parameter is itself another Expression
+                if (value is Expression expression)
                 {
-                    // The parameter is itself another Expression
-                    var expression = (Expression)value;
-
                     // Overloads parameters
                     foreach (var p in Parameters)
                     {
@@ -713,7 +711,7 @@ namespace NCalc.Domain
                     expression.EvaluateFunction += EvaluateFunction;
                     expression.EvaluateParameter += EvaluateParameter;
 
-                    Result = ((Expression)value).Evaluate();
+                    Result = expression.Evaluate();
                 }
                 else
                     Result = value;

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -168,7 +168,7 @@ namespace NCalc.Domain
                     // (since anything between 1 and 0 is not int and 0 is an exception anyway
                     Result = IsReal(left()) || IsReal(right())
                                  ? Numbers.Divide(left(), right(), _options, _cultureInfo)
-                                 : Numbers.Divide(Convert.ToDouble(left()), right(), _options, _cultureInfo);
+                                 : Numbers.Divide(Convert.ToDouble(left(), _cultureInfo), right(), _options, _cultureInfo);
                     break;
 
                 case BinaryExpressionType.Equal:

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -198,7 +198,7 @@ namespace NCalc.Domain
 
                 case BinaryExpressionType.Minus:
                     Result = Checked
-                        ? Numbers.SoustractChecked(left(), right(), _options, _cultureInfo)
+                        ? Numbers.SubtractChecked(left(), right(), _options, _cultureInfo)
                         : Numbers.Subtract(left(), right(), _options, _cultureInfo);
                     break;
 

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace NCalc.Domain
 {
@@ -8,15 +9,19 @@ namespace NCalc.Domain
         private delegate T Func<T>();
 
         private readonly EvaluateOptions _options = EvaluateOptions.None;
+        private readonly CultureInfo _cultureInfo = CultureInfo.CurrentCulture;
 
         private bool IgnoreCase { get { return (_options & EvaluateOptions.IgnoreCase) == EvaluateOptions.IgnoreCase; } }
         private bool Ordinal { get { return (_options & EvaluateOptions.MatchStringsOrdinal) == EvaluateOptions.MatchStringsOrdinal; } }
         private bool IgnoreCaseString { get { return (_options & EvaluateOptions.MatchStringsWithIgnoreCase) == EvaluateOptions.MatchStringsWithIgnoreCase; } }
         private bool Checked { get { return (_options & EvaluateOptions.OverflowProtection) == EvaluateOptions.OverflowProtection; } }
 
-        public EvaluationVisitor(EvaluateOptions options)
+        public EvaluationVisitor(EvaluateOptions options) : this(options, CultureInfo.CurrentCulture) { }
+
+        private EvaluationVisitor(EvaluateOptions options, CultureInfo cultureInfo)
         {
             _options = options;
+            _cultureInfo = cultureInfo;
         }
 
         public object Result { get; protected set; }
@@ -69,8 +74,8 @@ namespace NCalc.Domain
                 return -1;
             }
 
-            a = Convert.ChangeType(a, mpt);
-            b = Convert.ChangeType(b, mpt);
+            a = Convert.ChangeType(a, mpt, _cultureInfo);
+            b = Convert.ChangeType(b, mpt, _cultureInfo);
 
             if (mpt.Equals(typeof(string)) && (Ordinal || IgnoreCaseString))
             {
@@ -99,7 +104,7 @@ namespace NCalc.Domain
         {
             // Evaluates the left expression and saves the value
             expression.LeftExpression.Accept(this);
-            bool left = Convert.ToBoolean(Result);
+            bool left = Convert.ToBoolean(Result, _cultureInfo);
 
             if (left)
             {
@@ -150,11 +155,11 @@ namespace NCalc.Domain
             switch (expression.Type)
             {
                 case BinaryExpressionType.And:
-                    Result = Convert.ToBoolean(left()) && Convert.ToBoolean(right());
+                    Result = Convert.ToBoolean(left(), _cultureInfo) && Convert.ToBoolean(right(), _cultureInfo);
                     break;
 
                 case BinaryExpressionType.Or:
-                    Result = Convert.ToBoolean(left()) || Convert.ToBoolean(right());
+                    Result = Convert.ToBoolean(left(), _cultureInfo) || Convert.ToBoolean(right(), _cultureInfo);
                     break;
 
                 case BinaryExpressionType.Div:
@@ -162,8 +167,8 @@ namespace NCalc.Domain
                     // checked does nothing, and if they are int the result will only be same or smaller
                     // (since anything between 1 and 0 is not int and 0 is an exception anyway
                     Result = IsReal(left()) || IsReal(right())
-                                 ? Numbers.Divide(left(), right(), _options)
-                                 : Numbers.Divide(Convert.ToDouble(left()), right(), _options);
+                                 ? Numbers.Divide(left(), right(), _options, _cultureInfo)
+                                 : Numbers.Divide(left(), right(), _options, _cultureInfo);
                     break;
 
                 case BinaryExpressionType.Equal:
@@ -193,13 +198,13 @@ namespace NCalc.Domain
 
                 case BinaryExpressionType.Minus:
                     Result = Checked
-                        ? Numbers.SoustractChecked(left(), right(), _options)
-                        : Numbers.Soustract(left(), right(), _options);
+                        ? Numbers.SoustractChecked(left(), right(), _options, _cultureInfo)
+                        : Numbers.Subtract(left(), right(), _options, _cultureInfo);
                     break;
 
 
                 case BinaryExpressionType.Modulo:
-                    Result = Numbers.Modulo(left(), right());
+                    Result = Numbers.Modulo(left(), right(), _cultureInfo);
                     break;
 
                 case BinaryExpressionType.NotEqual:
@@ -215,40 +220,40 @@ namespace NCalc.Domain
                     else
                     {
                         Result = Checked
-                            ? Numbers.AddChecked(left(), right(), _options)
-                            : Numbers.Add(left(), right(), _options);
+                            ? Numbers.AddChecked(left(), right(), _options, _cultureInfo)
+                            : Numbers.Add(left(), right(), _options, _cultureInfo);
                     }
 
                     break;
 
                 case BinaryExpressionType.Times:
                     Result = Checked
-                        ? Numbers.MultiplyChecked(left(), right(), _options)
-                        : Numbers.Multiply(left(), right(), _options);
+                        ? Numbers.MultiplyChecked(left(), right(), _options, _cultureInfo)
+                        : Numbers.Multiply(left(), right(), _options, _cultureInfo);
                     break;
 
                 case BinaryExpressionType.BitwiseAnd:
-                    Result = Convert.ToUInt16(left()) & Convert.ToUInt16(right());
+                    Result = Convert.ToUInt16(left(), _cultureInfo) & Convert.ToUInt16(right(), _cultureInfo);
                     break;
 
 
                 case BinaryExpressionType.BitwiseOr:
-                    Result = Convert.ToUInt16(left()) | Convert.ToUInt16(right());
+                    Result = Convert.ToUInt16(left(), _cultureInfo) | Convert.ToUInt16(right(), _cultureInfo);
                     break;
 
 
                 case BinaryExpressionType.BitwiseXOr:
-                    Result = Convert.ToUInt16(left()) ^ Convert.ToUInt16(right());
+                    Result = Convert.ToUInt16(left(), _cultureInfo) ^ Convert.ToUInt16(right(), _cultureInfo);
                     break;
 
 
                 case BinaryExpressionType.LeftShift:
-                    Result = Convert.ToUInt16(left()) << Convert.ToUInt16(right());
+                    Result = Convert.ToUInt16(left(), _cultureInfo) << Convert.ToUInt16(right(), _cultureInfo);
                     break;
 
 
                 case BinaryExpressionType.RightShift:
-                    Result = Convert.ToUInt16(left()) >> Convert.ToUInt16(right());
+                    Result = Convert.ToUInt16(left(), _cultureInfo) >> Convert.ToUInt16(right(), _cultureInfo);
                     break;
             }
         }
@@ -261,15 +266,15 @@ namespace NCalc.Domain
             switch (expression.Type)
             {
                 case UnaryExpressionType.Not:
-                    Result = !Convert.ToBoolean(Result);
+                    Result = !Convert.ToBoolean(Result, _cultureInfo);
                     break;
 
                 case UnaryExpressionType.Negate:
-                    Result = Numbers.Soustract(0, Result, _options);
+                    Result = Numbers.Subtract(0, Result, _options, _cultureInfo);
                     break;
 
                 case UnaryExpressionType.BitwiseNot:
-                    Result = ~Convert.ToUInt16(Result);
+                    Result = ~Convert.ToUInt16(Result, _cultureInfo);
                     break;
             }
         }
@@ -300,7 +305,7 @@ namespace NCalc.Domain
             }
 
             // Calls external implementation
-            OnEvaluateFunction(IgnoreCase ? function.Identifier.Name.ToLower() : function.Identifier.Name, args);
+            OnEvaluateFunction(IgnoreCase ? function.Identifier.Name.ToLower(_cultureInfo) : function.Identifier.Name, args);
 
             // If an external implementation was found get the result back
             if (args.HasResult)
@@ -323,14 +328,12 @@ namespace NCalc.Domain
                     if (useDouble)
                     {
                         Result = Math.Abs(Convert.ToDouble(
-                                                  Evaluate(function.Expressions[0]))
-                        );
+                            Evaluate(function.Expressions[0]), _cultureInfo));
                     }
                     else
                     {
                         Result = Math.Abs(Convert.ToDecimal(
-                                                  Evaluate(function.Expressions[0]))
-                        );
+                            Evaluate(function.Expressions[0]), _cultureInfo));
                     }
 
                     break;
@@ -345,7 +348,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Acos() takes exactly 1 argument");
 
-                    Result = Math.Acos(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Acos(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -359,7 +363,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Asin() takes exactly 1 argument");
 
-                    Result = Math.Asin(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Asin(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -373,7 +378,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Atan() takes exactly 1 argument");
 
-                    Result = Math.Atan(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Atan(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -387,7 +393,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Ceiling() takes exactly 1 argument");
 
-                    Result = Math.Ceiling(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Ceiling(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -402,7 +409,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Cos() takes exactly 1 argument");
 
-                    Result = Math.Cos(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Cos(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -416,7 +424,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Exp() takes exactly 1 argument");
 
-                    Result = Math.Exp(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Exp(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -430,7 +439,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Floor() takes exactly 1 argument");
 
-                    Result = Math.Floor(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Floor(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -444,7 +454,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 2)
                         throw new ArgumentException("IEEERemainder() takes exactly 2 arguments");
 
-                    Result = Math.IEEERemainder(Convert.ToDouble(Evaluate(function.Expressions[0])), Convert.ToDouble(Evaluate(function.Expressions[1])));
+                    Result = Math.IEEERemainder(Convert.ToDouble(Evaluate(function.Expressions[0]), _cultureInfo),
+                        Convert.ToDouble(Evaluate(function.Expressions[1]), _cultureInfo));
 
                     break;
 
@@ -458,7 +469,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 3)
                         throw new ArgumentException("if() takes exactly 3 arguments");
 
-                    bool cond = Convert.ToBoolean(Evaluate(function.Expressions[0]));
+                    bool cond = Convert.ToBoolean(
+                        Evaluate(function.Expressions[0]), _cultureInfo);
 
                     Result = cond ? Evaluate(function.Expressions[1]) : Evaluate(function.Expressions[2]);
                     break;
@@ -501,7 +513,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 2)
                         throw new ArgumentException("Log() takes exactly 2 arguments");
 
-                    Result = Math.Log(Convert.ToDouble(Evaluate(function.Expressions[0])), Convert.ToDouble(Evaluate(function.Expressions[1])));
+                    Result = Math.Log(Convert.ToDouble(Evaluate(function.Expressions[0]), _cultureInfo),
+                        Convert.ToDouble(Evaluate(function.Expressions[1]), _cultureInfo));
 
                     break;
 
@@ -515,7 +528,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Log10() takes exactly 1 argument");
 
-                    Result = Math.Log10(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Log10(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -532,7 +546,7 @@ namespace NCalc.Domain
                     object maxleft = Evaluate(function.Expressions[0]);
                     object maxright = Evaluate(function.Expressions[1]);
 
-                    Result = Numbers.Max(maxleft, maxright);
+                    Result = Numbers.Max(maxleft, maxright, _cultureInfo);
                     break;
 
                 #endregion
@@ -548,7 +562,7 @@ namespace NCalc.Domain
                     object minleft = Evaluate(function.Expressions[0]);
                     object minright = Evaluate(function.Expressions[1]);
 
-                    Result = Numbers.Min(minleft, minright);
+                    Result = Numbers.Min(minleft, minright, _cultureInfo);
                     break;
 
                 #endregion
@@ -561,7 +575,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 2)
                         throw new ArgumentException("Pow() takes exactly 2 arguments");
 
-                    Result = Math.Pow(Convert.ToDouble(Evaluate(function.Expressions[0])), Convert.ToDouble(Evaluate(function.Expressions[1])));
+                    Result = Math.Pow(Convert.ToDouble(Evaluate(function.Expressions[0]), _cultureInfo),
+                        Convert.ToDouble(Evaluate(function.Expressions[1]), _cultureInfo));
 
                     break;
 
@@ -577,7 +592,8 @@ namespace NCalc.Domain
 
                     MidpointRounding rounding = (_options & EvaluateOptions.RoundAwayFromZero) == EvaluateOptions.RoundAwayFromZero ? MidpointRounding.AwayFromZero : MidpointRounding.ToEven;
 
-                    Result = Math.Round(Convert.ToDouble(Evaluate(function.Expressions[0])), Convert.ToInt16(Evaluate(function.Expressions[1])), rounding);
+                    Result = Math.Round(Convert.ToDouble(Evaluate(function.Expressions[0]), _cultureInfo),
+                        Convert.ToInt16(Evaluate(function.Expressions[1]), _cultureInfo), rounding);
 
                     break;
 
@@ -591,7 +607,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Sign() takes exactly 1 argument");
 
-                    Result = Math.Sign(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Sign(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -605,7 +622,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Sin() takes exactly 1 argument");
 
-                    Result = Math.Sin(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Sin(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -619,7 +637,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Sqrt() takes exactly 1 argument");
 
-                    Result = Math.Sqrt(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Sqrt(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -633,7 +652,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Tan() takes exactly 1 argument");
 
-                    Result = Math.Tan(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Tan(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -647,7 +667,8 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Truncate() takes exactly 1 argument");
 
-                    Result = Math.Truncate(Convert.ToDouble(Evaluate(function.Expressions[0])));
+                    Result = Math.Truncate(Convert.ToDouble(
+                        Evaluate(function.Expressions[0]), _cultureInfo));
 
                     break;
 
@@ -675,13 +696,13 @@ namespace NCalc.Domain
 
         public override void Visit(Identifier parameter)
         {
-            if (Parameters.ContainsKey(parameter.Name))
+            if (Parameters.TryGetValue(parameter.Name, out object value))
             {
                 // The parameter is defined in the hashtable
-                if (Parameters[parameter.Name] is Expression)
+                if (value is Expression)
                 {
                     // The parameter is itself another Expression
-                    var expression = (Expression)Parameters[parameter.Name];
+                    var expression = (Expression)value;
 
                     // Overloads parameters
                     foreach (var p in Parameters)
@@ -692,10 +713,10 @@ namespace NCalc.Domain
                     expression.EvaluateFunction += EvaluateFunction;
                     expression.EvaluateParameter += EvaluateParameter;
 
-                    Result = ((Expression)Parameters[parameter.Name]).Evaluate();
+                    Result = ((Expression)value).Evaluate();
                 }
                 else
-                    Result = Parameters[parameter.Name];
+                    Result = value;
             }
             else
             {
@@ -721,6 +742,5 @@ namespace NCalc.Domain
         }
 
         public Dictionary<string, object> Parameters { get; set; }
-
     }
 }

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -18,7 +18,7 @@ namespace NCalc.Domain
 
         public EvaluationVisitor(EvaluateOptions options) : this(options, CultureInfo.CurrentCulture) { }
 
-        private EvaluationVisitor(EvaluateOptions options, CultureInfo cultureInfo)
+        public EvaluationVisitor(EvaluateOptions options, CultureInfo cultureInfo)
         {
             _options = options;
             _cultureInfo = cultureInfo;

--- a/src/NCalc/Domain/Function.cs
+++ b/src/NCalc/Domain/Function.cs
@@ -1,18 +1,18 @@
 namespace NCalc.Domain
 {
-	public class Function : LogicalExpression
-	{
-		public Function(Identifier identifier, LogicalExpression[] expressions)
-		{
+    public class Function : LogicalExpression
+    {
+        public Function(Identifier identifier, LogicalExpression[] expressions)
+        {
             Identifier = identifier;
             Expressions = expressions;
-		}
+        }
 
-	    public Identifier Identifier { get; set; }
+        public Identifier Identifier { get; set; }
 
-	    public LogicalExpression[] Expressions { get; set; }
+        public LogicalExpression[] Expressions { get; set; }
 
-	    public override void Accept(LogicalExpressionVisitor visitor)
+        public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
         }

--- a/src/NCalc/Domain/LogicalExpression.cs
+++ b/src/NCalc/Domain/LogicalExpression.cs
@@ -2,8 +2,6 @@ namespace NCalc.Domain
 {
     public abstract class LogicalExpression
     {
-        const char BS = '\\';
-
         public BinaryExpression And(LogicalExpression operand)
         {
             return new BinaryExpression(BinaryExpressionType.And, this, operand);

--- a/src/NCalc/Domain/LogicalExpressionVisitor.cs
+++ b/src/NCalc/Domain/LogicalExpressionVisitor.cs
@@ -7,7 +7,7 @@ namespace NCalc.Domain
         public abstract void Visit(TernaryExpression expression);
         public abstract void Visit(BinaryExpression expression);
         public abstract void Visit(UnaryExpression expression);
-	    public abstract void Visit(ValueExpression expression);
+        public abstract void Visit(ValueExpression expression);
         public abstract void Visit(Function function);
         public abstract void Visit(Identifier function);
     }

--- a/src/NCalc/Domain/Parameter.cs
+++ b/src/NCalc/Domain/Parameter.cs
@@ -1,16 +1,16 @@
 namespace NCalc.Domain
 {
-	public class Identifier : LogicalExpression
-	{
-		public Identifier(string name)
-		{
+    public class Identifier : LogicalExpression
+    {
+        public Identifier(string name)
+        {
             Name = name;
-		}
+        }
 
-	    public string Name { get; set; }
+        public string Name { get; set; }
 
 
-	    public override void Accept(LogicalExpressionVisitor visitor)
+        public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
         }

--- a/src/NCalc/Domain/SerializationVisitor.cs
+++ b/src/NCalc/Domain/SerializationVisitor.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Text;
 using System.Globalization;
+using System.Text;
 
 namespace NCalc.Domain
 {
@@ -11,7 +11,7 @@ namespace NCalc.Domain
         public SerializationVisitor()
         {
             Result = new StringBuilder();
-            _numberFormatInfo = new NumberFormatInfo {NumberDecimalSeparator = "."};
+            _numberFormatInfo = new NumberFormatInfo { NumberDecimalSeparator = "." };
         }
 
         public StringBuilder Result { get; protected set; }
@@ -121,15 +121,15 @@ namespace NCalc.Domain
             switch (expression.Type)
             {
                 case UnaryExpressionType.Not:
-                    Result.Append("!");
+                    Result.Append('!');
                     break;
 
                 case UnaryExpressionType.Negate:
-                    Result.Append("-");
+                    Result.Append('-');
                     break;
 
                 case UnaryExpressionType.BitwiseNot:
-                    Result.Append("~");
+                    Result.Append('~');
                     break;
             }
 
@@ -141,23 +141,23 @@ namespace NCalc.Domain
             switch (expression.Type)
             {
                 case ValueType.Boolean:
-                    Result.Append(expression.Value.ToString()).Append(" ");
+                    Result.Append(expression.Value.ToString()).Append(' ');
                     break;
 
                 case ValueType.DateTime:
-                    Result.Append("#").Append(expression.Value.ToString()).Append("#").Append(" ");
+                    Result.Append('#').Append(expression.Value.ToString()).Append('#').Append(' ');
                     break;
 
                 case ValueType.Float:
-                    Result.Append(decimal.Parse(expression.Value.ToString(), NumberStyles.Any).ToString(_numberFormatInfo)).Append(" ");
+                    Result.Append(decimal.Parse(expression.Value.ToString(), NumberStyles.Any).ToString(_numberFormatInfo)).Append(' ');
                     break;
 
                 case ValueType.Integer:
-                    Result.Append(expression.Value.ToString()).Append(" ");
+                    Result.Append(expression.Value.ToString()).Append(' ');
                     break;
 
                 case ValueType.String:
-                    Result.Append("'").Append(expression.Value.ToString()).Append("'").Append(" ");
+                    Result.Append('\'').Append(expression.Value.ToString()).Append('\'').Append(' ');
                     break;
             }
         }
@@ -166,12 +166,12 @@ namespace NCalc.Domain
         {
             Result.Append(function.Identifier.Name);
 
-            Result.Append("(");
+            Result.Append('(');
 
-            for(int i=0; i<function.Expressions.Length; i++)
+            for (int i = 0; i < function.Expressions.Length; i++)
             {
                 function.Expressions[i].Accept(this);
-                if (i < function.Expressions.Length-1)
+                if (i < function.Expressions.Length - 1)
                 {
                     Result.Remove(Result.Length - 1, 1);
                     Result.Append(", ");
@@ -187,7 +187,7 @@ namespace NCalc.Domain
 
         public override void Visit(Identifier parameter)
         {
-            Result.Append("[").Append(parameter.Name).Append("] ");
+            Result.Append('[').Append(parameter.Name).Append("] ");
         }
 
         protected void EncapsulateNoValue(LogicalExpression expression)
@@ -198,13 +198,13 @@ namespace NCalc.Domain
             }
             else
             {
-                Result.Append("(");
+                Result.Append('(');
                 expression.Accept(this);
-                
+
                 // trim spaces before adding a closing paren
-                while(Result[Result.Length - 1] == ' ')
+                while (Result[Result.Length - 1] == ' ')
                     Result.Remove(Result.Length - 1, 1);
-                
+
                 Result.Append(") ");
             }
         }

--- a/src/NCalc/Domain/TernaryExpression.cs
+++ b/src/NCalc/Domain/TernaryExpression.cs
@@ -1,24 +1,24 @@
 ﻿namespace NCalc.Domain
 {
-	public class TernaryExpression : LogicalExpression
-	{
+    public class TernaryExpression : LogicalExpression
+    {
         public TernaryExpression(LogicalExpression leftExpression, LogicalExpression middleExpression, LogicalExpression rightExpression)
-		{
+        {
             this.LeftExpression = leftExpression;
             this.MiddleExpression = middleExpression;
             this.RightExpression = rightExpression;
-		}
+        }
 
-	    public LogicalExpression LeftExpression { get; set; }
+        public LogicalExpression LeftExpression { get; set; }
 
-	    public LogicalExpression MiddleExpression { get; set; }
+        public LogicalExpression MiddleExpression { get; set; }
 
-	    public LogicalExpression RightExpression { get; set; }
+        public LogicalExpression RightExpression { get; set; }
 
-	    public override void Accept(LogicalExpressionVisitor visitor)
+        public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
         }
 
-    }   
+    }
 }

--- a/src/NCalc/Domain/UnaryExpression.cs
+++ b/src/NCalc/Domain/UnaryExpression.cs
@@ -1,27 +1,27 @@
 namespace NCalc.Domain
 {
-	public class UnaryExpression : LogicalExpression
+    public class UnaryExpression : LogicalExpression
     {
-		public UnaryExpression(UnaryExpressionType type, LogicalExpression expression)
-		{
+        public UnaryExpression(UnaryExpressionType type, LogicalExpression expression)
+        {
             Type = type;
             Expression = expression;
-		}
+        }
 
-	    public LogicalExpression Expression { get; set; }
+        public LogicalExpression Expression { get; set; }
 
-	    public UnaryExpressionType Type { get; set; }
+        public UnaryExpressionType Type { get; set; }
 
-	    public override void Accept(LogicalExpressionVisitor visitor)
+        public override void Accept(LogicalExpressionVisitor visitor)
         {
             visitor.Visit(this);
         }
-	}
+    }
 
-	public enum UnaryExpressionType
-	{
-		Not,
+    public enum UnaryExpressionType
+    {
+        Not,
         Negate,
         BitwiseNot
-	}
+    }
 }

--- a/src/NCalc/Domain/Value.cs
+++ b/src/NCalc/Domain/Value.cs
@@ -1,13 +1,12 @@
 using System;
-using System.Reflection;
 
 namespace NCalc.Domain
 {
-	public class ValueExpression : LogicalExpression
-	{
+    public class ValueExpression : LogicalExpression
+    {
 
- 	public ValueExpression() {}
-  
+        public ValueExpression() { }
+
         public ValueExpression(object value, ValueType type)
         {
             Value = value;
@@ -18,11 +17,11 @@ namespace NCalc.Domain
         {
             switch (value.GetTypeCode())
             {
-                case TypeCode.Boolean :
+                case TypeCode.Boolean:
                     Type = ValueType.Boolean;
                     break;
 
-                case TypeCode.DateTime :
+                case TypeCode.DateTime:
                     Type = ValueType.DateTime;
                     break;
 
@@ -93,12 +92,12 @@ namespace NCalc.Domain
         }
     }
 
-	public enum ValueType
-	{
-		Integer,
-		String,
-		DateTime,
-		Float,
-		Boolean
-	}
+    public enum ValueType
+    {
+        Integer,
+        String,
+        DateTime,
+        Float,
+        Boolean
+    }
 }

--- a/src/NCalc/EvaluationException.cs
+++ b/src/NCalc/EvaluationException.cs
@@ -2,6 +2,7 @@
 
 namespace NCalc
 {
+    [Serializable]
     public class EvaluationException : Exception
     {
         public EvaluationException(string message)

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using NCalc.Domain;
-using Antlr4.Runtime;
-using System.Collections.Concurrent;
-using System.Linq;
-using Antlr4.Runtime.Misc;
+﻿using Antlr4.Runtime;
 using Antlr4.Runtime.Atn;
+using Antlr4.Runtime.Misc;
+using NCalc.Domain;
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NCalc
 {
@@ -27,7 +27,7 @@ namespace NCalc
         {
             if (String.IsNullOrEmpty(expression))
                 throw new
-                    ArgumentException("Expression can't be empty", "expression");
+                    ArgumentException("Expression can't be empty", nameof(expression));
 
             OriginalExpression = expression;
             Options = options;
@@ -41,7 +41,7 @@ namespace NCalc
         {
             if (expression == null)
                 throw new
-                    ArgumentException("Expression can't be null", "expression");
+                    ArgumentException("Expression can't be null", nameof(expression));
 
             ParsedExpression = expression;
             Options = options;
@@ -133,7 +133,7 @@ namespace NCalc
                 {
                     logicalExpression = parser.ncalcExpression().value;
                 }
-                catch(ParseCanceledException)
+                catch (ParseCanceledException)
                 {
                     lexer.Reset();
 

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace NCalc
@@ -19,11 +20,25 @@ namespace NCalc
         /// </summary>
         protected string OriginalExpression;
 
-        public Expression(string expression) : this(expression, EvaluateOptions.None)
+        /// <summary>
+        /// Get or set the culture info.
+        /// </summary>
+        protected CultureInfo CultureInfo { get; set; }
+
+
+        public Expression(string expression) : this(expression, EvaluateOptions.None, CultureInfo.CurrentCulture)
         {
         }
 
-        public Expression(string expression, EvaluateOptions options)
+        public Expression(string expression, CultureInfo cultureInfo) : this(expression, EvaluateOptions.None, cultureInfo)
+        {
+        }
+
+        public Expression(string expression, EvaluateOptions options) : this(expression, options, CultureInfo.CurrentCulture)
+        {
+        }
+
+        public Expression(string expression, EvaluateOptions options, CultureInfo cultureInfo)
         {
             if (String.IsNullOrEmpty(expression))
                 throw new
@@ -31,13 +46,14 @@ namespace NCalc
 
             OriginalExpression = expression;
             Options = options;
+            CultureInfo = cultureInfo;
         }
 
-        public Expression(LogicalExpression expression) : this(expression, EvaluateOptions.None)
+        public Expression(LogicalExpression expression, EvaluateOptions options): this(expression, options, CultureInfo.CurrentCulture) 
         {
         }
 
-        public Expression(LogicalExpression expression, EvaluateOptions options)
+        public Expression(LogicalExpression expression, EvaluateOptions options, CultureInfo cultureInfo)
         {
             if (expression == null)
                 throw new
@@ -45,6 +61,7 @@ namespace NCalc
 
             ParsedExpression = expression;
             Options = options;
+            CultureInfo = cultureInfo;
         }
 
         #region Cache management
@@ -276,7 +293,7 @@ namespace NCalc
             }
 
 
-            var visitor = new EvaluationVisitor(Options);
+            var visitor = new EvaluationVisitor(Options, CultureInfo);
             visitor.EvaluateFunction += EvaluateFunction;
             visitor.EvaluateParameter += EvaluateParameter;
             visitor.Parameters = Parameters;

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -49,7 +49,7 @@ namespace NCalc
             CultureInfo = cultureInfo;
         }
 
-        public Expression(LogicalExpression expression, EvaluateOptions options): this(expression, options, CultureInfo.CurrentCulture) 
+        public Expression(LogicalExpression expression, EvaluateOptions options) : this(expression, options, CultureInfo.CurrentCulture)
         {
         }
 
@@ -121,14 +121,13 @@ namespace NCalc
                 if (_compiledExpressions.ContainsKey(expression))
                 {
                     //Debug.WriteLine("Expression retrieved from cache: " + expression);
-                    if (_compiledExpressions.TryGetValue(expression, out var wr))
-                    {
-                        logicalExpression = wr.Target as LogicalExpression;
 
-                        if (wr.IsAlive && logicalExpression != null)
-                        {
-                            return logicalExpression;
-                        }
+                    var wr = _compiledExpressions[expression];
+                    logicalExpression = wr.Target as LogicalExpression;
+
+                    if (wr.IsAlive && logicalExpression != null)
+                    {
+                        return logicalExpression;
                     }
                 }
             }

--- a/src/NCalc/ExtendedMethodInfo.cs
+++ b/src/NCalc/ExtendedMethodInfo.cs
@@ -1,9 +1,9 @@
 ﻿using System.Reflection;
 using L = System.Linq.Expressions;
 
-namespace NCalc 
+namespace NCalc
 {
-    public class ExtendedMethodInfo 
+    public class ExtendedMethodInfo
     {
         public MethodInfo BaseMethodInfo { get; set; }
         public L.Expression[] PreparedArguments { get; set; }

--- a/src/NCalc/FunctionArgs.cs
+++ b/src/NCalc/FunctionArgs.cs
@@ -9,8 +9,8 @@ namespace NCalc
         public object Result
         {
             get { return _result; }
-            set 
-            { 
+            set
+            {
                 _result = value;
                 HasResult = true;
             }

--- a/src/NCalc/Numbers.cs
+++ b/src/NCalc/Numbers.cs
@@ -745,12 +745,24 @@ namespace NCalc
             return null;
         }
 
+        [Obsolete("This method will be removed in the next major update. Use SubtractChecked method instead")]
         public static object SoustractChecked(object a, object b, EvaluateOptions options)
         {
-            return SoustractChecked(a, b, options, CultureInfo.CurrentCulture);
+            return SubtractChecked(a, b, options, CultureInfo.CurrentCulture);
         }
 
+        [Obsolete("This method will be removed in the next major update. Use SubtractChecked method instead")]
         public static object SoustractChecked(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
+        {
+            return SubtractChecked(a, b, options, cultureInfo);
+        }
+
+        public static object SubtractChecked(object a, object b, EvaluateOptions options)
+        {
+            return SubtractChecked(a, b, options, CultureInfo.CurrentCulture);
+        }
+
+        public static object SubtractChecked(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
         {
             a = ConvertIfString(a, cultureInfo);
             b = ConvertIfString(b, cultureInfo);

--- a/src/NCalc/Numbers.cs
+++ b/src/NCalc/Numbers.cs
@@ -1,16 +1,15 @@
 ﻿using System;
-using System.Collections;
-using System.Security.Cryptography;
+using System.Globalization;
 
 namespace NCalc
 {
-    public class Numbers
+    public static class Numbers
     {
-        private static object ConvertIfString(object s)
+        private static object ConvertIfString(object s, CultureInfo cultureInfo)
         {
-            if (s is String|| s is char)
+            if (s is String || s is char)
             {
-                return Decimal.Parse(s.ToString());
+                return Decimal.Parse(s.ToString(), cultureInfo);
             }
 
             return s;
@@ -28,8 +27,13 @@ namespace NCalc
 
         public static object Add(object a, object b, EvaluateOptions options)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return Add(a, b, options, CultureInfo.CurrentCulture);
+        }
+
+        public static object Add(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             if (options.HasFlag(EvaluateOptions.BooleanCalculation))
             {
@@ -216,7 +220,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Single)a + (UInt64)b;
                         case TypeCode.Single: return (Single)a + (Single)b;
                         case TypeCode.Double: return (Single)a + (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) + (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) + (Decimal)b;
                     }
                     break;
 
@@ -234,7 +238,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Double)a + (UInt64)b;
                         case TypeCode.Single: return (Double)a + (Single)b;
                         case TypeCode.Double: return (Double)a + (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) + (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) + (Decimal)b;
                     }
                     break;
 
@@ -250,8 +254,8 @@ namespace NCalc
                         case TypeCode.UInt32: return (Decimal)a + (UInt32)b;
                         case TypeCode.Int64: return (Decimal)a + (Int64)b;
                         case TypeCode.UInt64: return (Decimal)a + (UInt64)b;
-                        case TypeCode.Single: return (Decimal)a + Convert.ToDecimal(b);
-                        case TypeCode.Double: return (Decimal)a + Convert.ToDecimal(b);
+                        case TypeCode.Single: return (Decimal)a + Convert.ToDecimal(b, cultureInfo);
+                        case TypeCode.Double: return (Decimal)a + Convert.ToDecimal(b, cultureInfo);
                         case TypeCode.Decimal: return (Decimal)a + (Decimal)b;
                     }
                     break;
@@ -262,8 +266,13 @@ namespace NCalc
 
         public static object AddChecked(object a, object b, EvaluateOptions options)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return AddChecked(a, b, options, CultureInfo.CurrentCulture);
+        }
+
+        public static object AddChecked(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             if (options.HasFlag(EvaluateOptions.BooleanCalculation))
             {
@@ -451,7 +460,7 @@ namespace NCalc
                             case TypeCode.UInt64: return (Single)a + (UInt64)b;
                             case TypeCode.Single: return (Single)a + (Single)b;
                             case TypeCode.Double: return (Single)a + (Double)b;
-                            case TypeCode.Decimal: return Convert.ToDecimal(a) + (Decimal)b;
+                            case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) + (Decimal)b;
                         }
                         break;
 
@@ -469,7 +478,7 @@ namespace NCalc
                             case TypeCode.UInt64: return (Double)a + (UInt64)b;
                             case TypeCode.Single: return (Double)a + (Single)b;
                             case TypeCode.Double: return (Double)a + (Double)b;
-                            case TypeCode.Decimal: return Convert.ToDecimal(a) + (Decimal)b;
+                            case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) + (Decimal)b;
                         }
                         break;
 
@@ -485,8 +494,8 @@ namespace NCalc
                             case TypeCode.UInt32: return (Decimal)a + (UInt32)b;
                             case TypeCode.Int64: return (Decimal)a + (Int64)b;
                             case TypeCode.UInt64: return (Decimal)a + (UInt64)b;
-                            case TypeCode.Single: return (Decimal)a + Convert.ToDecimal(b);
-                            case TypeCode.Double: return (Decimal)a + Convert.ToDecimal(b);
+                            case TypeCode.Single: return (Decimal)a + Convert.ToDecimal(b, cultureInfo);
+                            case TypeCode.Double: return (Decimal)a + Convert.ToDecimal(b, cultureInfo);
                             case TypeCode.Decimal: return (Decimal)a + (Decimal)b;
                         }
                         break;
@@ -496,10 +505,27 @@ namespace NCalc
             }
         }
 
+        [Obsolete("This method will be removed in the next major update. Use Subtract method instead")]
         public static object Soustract(object a, object b, EvaluateOptions options)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return Subtract(a, b, options, CultureInfo.CurrentCulture);
+        }
+
+        [Obsolete("This method will be removed in the next major update. Use Subtract method instead")]
+        public static object Soustract(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
+        {
+            return Subtract(a, b, options, cultureInfo);
+        }
+
+        public static object Subtract(object a, object b, EvaluateOptions options)
+        {
+            return Subtract(a, b, options, CultureInfo.CurrentCulture);
+        }
+
+        public static object Subtract(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             if (options.HasFlag(EvaluateOptions.BooleanCalculation))
             {
@@ -677,7 +703,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Single)a - (UInt64)b;
                         case TypeCode.Single: return (Single)a - (Single)b;
                         case TypeCode.Double: return (Single)a - (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) - (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) - (Decimal)b;
                     }
                     break;
 
@@ -694,7 +720,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Double)a - (UInt64)b;
                         case TypeCode.Single: return (Double)a - (Single)b;
                         case TypeCode.Double: return (Double)a - (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) - (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) - (Decimal)b;
                     }
                     break;
 
@@ -709,8 +735,8 @@ namespace NCalc
                         case TypeCode.UInt32: return (Decimal)a - (UInt32)b;
                         case TypeCode.Int64: return (Decimal)a - (Int64)b;
                         case TypeCode.UInt64: return (Decimal)a - (UInt64)b;
-                        case TypeCode.Single: return (Decimal)a - Convert.ToDecimal(b);
-                        case TypeCode.Double: return (Decimal)a - Convert.ToDecimal(b);
+                        case TypeCode.Single: return (Decimal)a - Convert.ToDecimal(b, cultureInfo);
+                        case TypeCode.Double: return (Decimal)a - Convert.ToDecimal(b, cultureInfo);
                         case TypeCode.Decimal: return (Decimal)a - (Decimal)b;
                     }
                     break;
@@ -718,10 +744,16 @@ namespace NCalc
 
             return null;
         }
+
         public static object SoustractChecked(object a, object b, EvaluateOptions options)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return SoustractChecked(a, b, options, CultureInfo.CurrentCulture);
+        }
+
+        public static object SoustractChecked(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             if (options.HasFlag(EvaluateOptions.BooleanCalculation))
             {
@@ -900,7 +932,7 @@ namespace NCalc
                             case TypeCode.UInt64: return (Single)a - (UInt64)b;
                             case TypeCode.Single: return (Single)a - (Single)b;
                             case TypeCode.Double: return (Single)a - (Double)b;
-                            case TypeCode.Decimal: return Convert.ToDecimal(a) - (Decimal)b; 
+                            case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) - (Decimal)b;
                         }
                         break;
 
@@ -917,7 +949,7 @@ namespace NCalc
                             case TypeCode.UInt64: return (Double)a - (UInt64)b;
                             case TypeCode.Single: return (Double)a - (Single)b;
                             case TypeCode.Double: return (Double)a - (Double)b;
-                            case TypeCode.Decimal: return Convert.ToDecimal(a) - (Decimal)b;
+                            case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) - (Decimal)b;
                         }
                         break;
 
@@ -932,8 +964,8 @@ namespace NCalc
                             case TypeCode.UInt32: return (Decimal)a - (UInt32)b;
                             case TypeCode.Int64: return (Decimal)a - (Int64)b;
                             case TypeCode.UInt64: return (Decimal)a - (UInt64)b;
-                            case TypeCode.Single: return (Decimal)a - Convert.ToDecimal(b);
-                            case TypeCode.Double: return (Decimal)a - Convert.ToDecimal(b);
+                            case TypeCode.Single: return (Decimal)a - Convert.ToDecimal(b, cultureInfo);
+                            case TypeCode.Double: return (Decimal)a - Convert.ToDecimal(b, cultureInfo);
                             case TypeCode.Decimal: return (Decimal)a - (Decimal)b;
                         }
                         break;
@@ -941,10 +973,16 @@ namespace NCalc
             }
             return null;
         }
+
         public static object Multiply(object a, object b, EvaluateOptions options)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return Multiply(a, b, options, CultureInfo.CurrentCulture);
+        }
+
+        public static object Multiply(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             if (options.HasFlag(EvaluateOptions.BooleanCalculation))
             {
@@ -1105,7 +1143,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Single)a * (UInt64)b;
                         case TypeCode.Single: return (Single)a * (Single)b;
                         case TypeCode.Double: return (Single)a * (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) * (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) * (Decimal)b;
                     }
                     break;
 
@@ -1122,7 +1160,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Double)a * (UInt64)b;
                         case TypeCode.Single: return (Double)a * (Single)b;
                         case TypeCode.Double: return (Double)a * (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) * (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) * (Decimal)b;
                     }
                     break;
 
@@ -1137,8 +1175,8 @@ namespace NCalc
                         case TypeCode.UInt32: return (Decimal)a * (UInt32)b;
                         case TypeCode.Int64: return (Decimal)a * (Int64)b;
                         case TypeCode.UInt64: return (Decimal)a * (UInt64)b;
-                        case TypeCode.Single: return (Decimal)a * Convert.ToDecimal(b);
-                        case TypeCode.Double: return (Decimal)a * Convert.ToDecimal(b);
+                        case TypeCode.Single: return (Decimal)a * Convert.ToDecimal(b, cultureInfo);
+                        case TypeCode.Double: return (Decimal)a * Convert.ToDecimal(b, cultureInfo);
                         case TypeCode.Decimal: return (Decimal)a * (Decimal)b;
                     }
                     break;
@@ -1146,10 +1184,16 @@ namespace NCalc
 
             return null;
         }
+
         public static object MultiplyChecked(object a, object b, EvaluateOptions options)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return MultiplyChecked(a, b, options, CultureInfo.CurrentCulture);
+        }
+
+        public static object MultiplyChecked(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             if (options.HasFlag(EvaluateOptions.BooleanCalculation))
             {
@@ -1311,7 +1355,7 @@ namespace NCalc
                             case TypeCode.UInt64: return (Single)a * (UInt64)b;
                             case TypeCode.Single: return (Single)a * (Single)b;
                             case TypeCode.Double: return (Single)a * (Double)b;
-                            case TypeCode.Decimal: return Convert.ToDecimal(a) * (Decimal)b;
+                            case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) * (Decimal)b;
                         }
                         break;
 
@@ -1328,7 +1372,7 @@ namespace NCalc
                             case TypeCode.UInt64: return (Double)a * (UInt64)b;
                             case TypeCode.Single: return (Double)a * (Single)b;
                             case TypeCode.Double: return (Double)a * (Double)b;
-                            case TypeCode.Decimal: return Convert.ToDecimal(a) * (Decimal)b;
+                            case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) * (Decimal)b;
                         }
                         break;
 
@@ -1343,8 +1387,8 @@ namespace NCalc
                             case TypeCode.UInt32: return (Decimal)a * (UInt32)b;
                             case TypeCode.Int64: return (Decimal)a * (Int64)b;
                             case TypeCode.UInt64: return (Decimal)a * (UInt64)b;
-                            case TypeCode.Single: return (Decimal)a * Convert.ToDecimal(b);
-                            case TypeCode.Double: return (Decimal)a * Convert.ToDecimal(b);
+                            case TypeCode.Single: return (Decimal)a * Convert.ToDecimal(b, cultureInfo);
+                            case TypeCode.Double: return (Decimal)a * Convert.ToDecimal(b, cultureInfo);
                             case TypeCode.Decimal: return (Decimal)a * (Decimal)b;
                         }
                         break;
@@ -1352,10 +1396,16 @@ namespace NCalc
             }
             return null;
         }
+
         public static object Divide(object a, object b, EvaluateOptions options)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return Divide(a, b, options, CultureInfo.CurrentCulture);
+        }
+
+        public static object Divide(object a, object b, EvaluateOptions options, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             if (options.HasFlag(EvaluateOptions.BooleanCalculation))
             {
@@ -1516,7 +1566,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Single)a / (UInt64)b;
                         case TypeCode.Single: return (Single)a / (Single)b;
                         case TypeCode.Double: return (Single)a / (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) / (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) / (Decimal)b;
                     }
                     break;
 
@@ -1533,7 +1583,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Double)a / (UInt64)b;
                         case TypeCode.Single: return (Double)a / (Single)b;
                         case TypeCode.Double: return (Double)a / (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) / (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) / (Decimal)b;
                     }
                     break;
 
@@ -1548,8 +1598,8 @@ namespace NCalc
                         case TypeCode.UInt32: return (Decimal)a / (UInt32)b;
                         case TypeCode.Int64: return (Decimal)a / (Int64)b;
                         case TypeCode.UInt64: return (Decimal)a / (UInt64)b;
-                        case TypeCode.Single: return (Decimal)a / Convert.ToDecimal(b);
-                        case TypeCode.Double: return (Decimal)a / Convert.ToDecimal(b);
+                        case TypeCode.Single: return (Decimal)a / Convert.ToDecimal(b, cultureInfo);
+                        case TypeCode.Double: return (Decimal)a / Convert.ToDecimal(b, cultureInfo);
                         case TypeCode.Decimal: return (Decimal)a / (Decimal)b;
                     }
                     break;
@@ -1560,8 +1610,13 @@ namespace NCalc
 
         public static object Modulo(object a, object b)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return Modulo(a, b, CultureInfo.CurrentCulture);
+        }
+
+        public static object Modulo(object a, object b, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             TypeCode typeCodeA = a.GetTypeCode();
             TypeCode typeCodeB = b.GetTypeCode();
@@ -1716,7 +1771,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Single)a % (UInt64)b;
                         case TypeCode.Single: return (Single)a % (Single)b;
                         case TypeCode.Double: return (Single)a % (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) % (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) % (Decimal)b;
                     }
                     break;
 
@@ -1733,7 +1788,7 @@ namespace NCalc
                         case TypeCode.UInt64: return (Double)a % (UInt64)b;
                         case TypeCode.Single: return (Double)a % (Single)b;
                         case TypeCode.Double: return (Double)a % (Double)b;
-                        case TypeCode.Decimal: return Convert.ToDecimal(a) % (Decimal)b;
+                        case TypeCode.Decimal: return Convert.ToDecimal(a, cultureInfo) % (Decimal)b;
                     }
                     break;
 
@@ -1748,8 +1803,8 @@ namespace NCalc
                         case TypeCode.UInt32: return (Decimal)a % (UInt32)b;
                         case TypeCode.Int64: return (Decimal)a % (Int64)b;
                         case TypeCode.UInt64: return (Decimal)a % (UInt64)b;
-                        case TypeCode.Single: return (Decimal)a % Convert.ToDecimal(b);
-                        case TypeCode.Double: return (Decimal)a % Convert.ToDecimal(b);
+                        case TypeCode.Single: return (Decimal)a % Convert.ToDecimal(b, cultureInfo);
+                        case TypeCode.Double: return (Decimal)a % Convert.ToDecimal(b, cultureInfo);
                         case TypeCode.Decimal: return (Decimal)a % (Decimal)b;
                     }
                     break;
@@ -1757,10 +1812,16 @@ namespace NCalc
 
             return null;
         }
+
         public static object Max(object a, object b)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return Max(a, b, CultureInfo.CurrentCulture);
+        }
+
+        public static object Max(object a, object b, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             if (a == null && b == null)
             {
@@ -1777,7 +1838,7 @@ namespace NCalc
                 return a;
             }
 
-            TypeCode typeCode = ConvertToHighestPrecision(ref a, ref b);
+            TypeCode typeCode = ConvertToHighestPrecision(ref a, ref b, cultureInfo);
 
             switch (typeCode)
             {
@@ -1807,10 +1868,16 @@ namespace NCalc
 
             return null;
         }
+
         public static object Min(object a, object b)
         {
-            a = ConvertIfString(a);
-            b = ConvertIfString(b);
+            return Min(a, b, CultureInfo.CurrentCulture);
+        }
+
+        public static object Min(object a, object b, CultureInfo cultureInfo)
+        {
+            a = ConvertIfString(a, cultureInfo);
+            b = ConvertIfString(b, cultureInfo);
 
             if (a == null && b == null)
             {
@@ -1827,7 +1894,7 @@ namespace NCalc
                 return a;
             }
 
-            TypeCode typeCode = ConvertToHighestPrecision(ref a,ref b);
+            TypeCode typeCode = ConvertToHighestPrecision(ref a, ref b, cultureInfo);
 
             switch (typeCode)
             {
@@ -1858,13 +1925,12 @@ namespace NCalc
             return null;
         }
 
-
-        private static TypeCode ConvertToHighestPrecision(ref object a, ref object b)
+        private static TypeCode ConvertToHighestPrecision(ref object a, ref object b, CultureInfo cultureInfo)
         {
             TypeCode typeCodeA = a.GetTypeCode();
             TypeCode typeCodeB = b.GetTypeCode();
-            
-            if (typeCodeA==typeCodeB)
+
+            if (typeCodeA == typeCodeB)
                 return typeCodeA;
 
             if (!(TypeCodeBitSize(typeCodeA, out bool floatingPointA) is int bitSizeA))
@@ -1876,13 +1942,13 @@ namespace NCalc
             {
                 if (floatingPointA)
                 {
-                    b = ConvertTo(b, typeCodeA);
+                    b = ConvertTo(b, typeCodeA, cultureInfo);
 
                     return typeCodeA;
                 }
                 else
                 {
-                    a = ConvertTo(a, typeCodeB);
+                    a = ConvertTo(a, typeCodeB, cultureInfo);
 
                     return typeCodeB;
                 }
@@ -1890,20 +1956,20 @@ namespace NCalc
 
             if (bitSizeA > bitSizeB)
             {
-                b = ConvertTo(b, typeCodeA);
+                b = ConvertTo(b, typeCodeA, cultureInfo);
 
                 return typeCodeA;
             }
             else
             {
-                a = ConvertTo(a, typeCodeB);
+                a = ConvertTo(a, typeCodeB, cultureInfo);
 
                 return typeCodeB;
             }
-                
+
         }
 
-        private static int? TypeCodeBitSize(TypeCode typeCode,out bool floatingPoint)
+        private static int? TypeCodeBitSize(TypeCode typeCode, out bool floatingPoint)
         {
             floatingPoint = false;
             switch (typeCode)
@@ -1929,42 +1995,42 @@ namespace NCalc
             }
         }
 
-        private static object  ConvertTo(object value, TypeCode toType)
+        private static object ConvertTo(object value, TypeCode toType, CultureInfo cultureInfo)
         {
             switch (toType)
             {
                 case TypeCode.Byte:
-                    return Convert.ToByte(value);
+                    return Convert.ToByte(value, cultureInfo);
 
                 case TypeCode.SByte:
-                    return Convert.ToSByte(value);
+                    return Convert.ToSByte(value, cultureInfo);
 
                 case TypeCode.Int16:
-                    return Convert.ToInt16(value);
+                    return Convert.ToInt16(value, cultureInfo);
 
                 case TypeCode.UInt16:
-                    return Convert.ToUInt16(value);
+                    return Convert.ToUInt16(value, cultureInfo);
 
                 case TypeCode.Int32:
-                    return Convert.ToInt32(value);
+                    return Convert.ToInt32(value, cultureInfo);
 
                 case TypeCode.UInt32:
-                    return Convert.ToUInt32(value);
+                    return Convert.ToUInt32(value, cultureInfo);
 
                 case TypeCode.Int64:
-                    return Convert.ToInt64(value);
+                    return Convert.ToInt64(value, cultureInfo);
 
                 case TypeCode.UInt64:
-                    return Convert.ToUInt64(value);
+                    return Convert.ToUInt64(value, cultureInfo);
 
                 case TypeCode.Single:
-                    return Convert.ToSingle(value);
+                    return Convert.ToSingle(value, cultureInfo);
 
                 case TypeCode.Double:
-                    return Convert.ToDouble(value);
+                    return Convert.ToDouble(value, cultureInfo);
 
                 case TypeCode.Decimal:
-                    return Convert.ToDecimal(value);
+                    return Convert.ToDecimal(value, cultureInfo);
             }
 
             return null;

--- a/src/NCalc/TypeExtensions.cs
+++ b/src/NCalc/TypeExtensions.cs
@@ -25,20 +25,21 @@ namespace System
                 {typeof(string), TypeCode.String}
             };
 
-        public static TypeCode GetTypeCode(this object obj) 
+        public static TypeCode GetTypeCode(this object obj)
         {
             if (obj == null)
                 return TypeCode.Empty;
 
             return obj.GetType().ToTypeCode();
         }
-        public static TypeCode ToTypeCode(this Type type) 
+        public static TypeCode ToTypeCode(this Type type)
         {
             if (type == null)
                 return TypeCode.Empty;
 
             TypeCode tc;
-            if (!TypeCodeMap.TryGetValue(type, out tc)) {
+            if (!TypeCodeMap.TryGetValue(type, out tc))
+            {
                 tc = TypeCode.Object;
             }
 

--- a/test/NCalc.Tests/Extensions.cs
+++ b/test/NCalc.Tests/Extensions.cs
@@ -5,9 +5,9 @@ namespace NCalc.Tests
     internal static class Extensions
     {
         internal static Expression CreateExpression(string expression, CultureInfo? cultureInfo = null) =>
-           Extensions.CreateExpression(expression, cultureInfo ?? CultureInfo.InvariantCulture);
+           new Expression(expression, cultureInfo ?? CultureInfo.InvariantCulture);
 
         internal static Expression CreateExpression(string expression, EvaluateOptions evaluateOptions, CultureInfo? cultureInfo = null) =>
-           Extensions.CreateExpression(expression, evaluateOptions, cultureInfo ?? CultureInfo.InvariantCulture);
+           new Expression(expression, evaluateOptions, cultureInfo ?? CultureInfo.InvariantCulture);
     }
 }

--- a/test/NCalc.Tests/Extensions.cs
+++ b/test/NCalc.Tests/Extensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Globalization;
+
+namespace NCalc.Tests
+{
+    internal static class Extensions
+    {
+        internal static Expression CreateExpression(string expression, CultureInfo? cultureInfo = null) =>
+           Extensions.CreateExpression(expression, cultureInfo ?? CultureInfo.InvariantCulture);
+
+        internal static Expression CreateExpression(string expression, EvaluateOptions evaluateOptions, CultureInfo? cultureInfo = null) =>
+           Extensions.CreateExpression(expression, evaluateOptions, cultureInfo ?? CultureInfo.InvariantCulture);
+    }
+}

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -40,13 +40,13 @@ namespace NCalc.Tests
             foreach (string expression in expressions)
                 _output.WriteLine("{0} = {1}",
                     expression,
-                    new Expression(expression, CultureInfo.InvariantCulture).Evaluate());
+                    Extensions.CreateExpression(expression).Evaluate());
         }
 
         [Fact]
         public void ExpressionShouldHandleNullRightParameters()
         {
-            var e = new Expression("'a string' == null", EvaluateOptions.AllowNullParameter, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("'a string' == null", EvaluateOptions.AllowNullParameter);
 
             Assert.False((bool)e.Evaluate());
         }
@@ -54,7 +54,7 @@ namespace NCalc.Tests
         [Fact]
         public void ExpressionShouldHandleNullLeftParameters()
         {
-            var e = new Expression("null == 'a string'", EvaluateOptions.AllowNullParameter, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("null == 'a string'", EvaluateOptions.AllowNullParameter);
 
             Assert.False((bool)e.Evaluate());
         }
@@ -62,7 +62,7 @@ namespace NCalc.Tests
         [Fact]
         public void ExpressionShouldHandleNullBothParameters()
         {
-            var e = new Expression("null == null", EvaluateOptions.AllowNullParameter, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("null == null", EvaluateOptions.AllowNullParameter);
 
             Assert.True((bool)e.Evaluate());
         }
@@ -70,7 +70,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldCompareNullToNull()
         {
-            var e = new Expression("[x] = null", EvaluateOptions.AllowNullParameter, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("[x] = null", EvaluateOptions.AllowNullParameter);
 
             e.Parameters["x"] = null;
 
@@ -80,7 +80,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldCompareNullableToNonNullable()
         {
-            var e = new Expression("[x] = 5", EvaluateOptions.AllowNullParameter, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("[x] = 5", EvaluateOptions.AllowNullParameter);
 
             e.Parameters["x"] = (int?)5;
             Assert.True((bool)e.Evaluate());
@@ -92,7 +92,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldCompareNullableNullToNonNullable()
         {
-            var e = new Expression("[x] = 5", EvaluateOptions.AllowNullParameter, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("[x] = 5", EvaluateOptions.AllowNullParameter);
 
             e.Parameters["x"] = null;
             Assert.False((bool)e.Evaluate());
@@ -101,7 +101,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldCompareNullToString()
         {
-            var e = new Expression("[x] = 'foo'", EvaluateOptions.AllowNullParameter, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("[x] = 'foo'", EvaluateOptions.AllowNullParameter);
 
             e.Parameters["x"] = null;
 
@@ -111,7 +111,7 @@ namespace NCalc.Tests
         [Fact]
         public void ExpressionDoesNotDefineNullParameterWithoutNullOption()
         {
-            var e = new Expression("'a string' == null", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("'a string' == null");
 
             var ex = Assert.Throws<ArgumentException>(() => e.Evaluate());
             Assert.Contains("Parameter was not defined", ex.Message);
@@ -120,7 +120,7 @@ namespace NCalc.Tests
         [Fact]
         public void ExpressionThrowsNullReferenceExceptionWithoutNullOption()
         {
-            var e = new Expression("'a string' == null", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("'a string' == null");
 
             e.Parameters["null"] = null;
 
@@ -130,7 +130,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldEvaluateExcessiveNulls()
         {
-            var e = new Expression(GetNullsFormula(), EvaluateOptions.AllowNullParameter, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression(GetNullsFormula(), EvaluateOptions.AllowNullParameter);
 
             Assert.Null(e.Evaluate());
         }
@@ -146,7 +146,7 @@ namespace NCalc.Tests
 
             for (int i = 0; i < iterations; i++)
             {
-                new Expression(formula, EvaluateOptions.AllowNullParameter, CultureInfo.InvariantCulture).Evaluate();
+                Extensions.CreateExpression(formula, EvaluateOptions.AllowNullParameter).Evaluate();
             }
 
             stopwatch.Stop();
@@ -160,12 +160,12 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldParseValues()
         {
-            Assert.Equal(123456, new Expression("123456", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(new DateTime(2001, 01, 01), new Expression("#01/01/2001#", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(123.456d, new Expression("123.456", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal((object)true, new Expression("true", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal("true", new Expression("'true'", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal("azerty", new Expression("'azerty'", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal(123456, Extensions.CreateExpression("123456").Evaluate());
+            Assert.Equal(new DateTime(2001, 01, 01), Extensions.CreateExpression("#01/01/2001#").Evaluate());
+            Assert.Equal(123.456d, Extensions.CreateExpression("123.456").Evaluate());
+            Assert.Equal((object)true, Extensions.CreateExpression("true").Evaluate());
+            Assert.Equal("true", Extensions.CreateExpression("'true'").Evaluate());
+            Assert.Equal("azerty", Extensions.CreateExpression("'azerty'").Evaluate());
         }
 
         [Fact]
@@ -173,7 +173,7 @@ namespace NCalc.Tests
         {
             // small decimals starting with 0 resulting in scientific notation did not work in original NCalc
             var equation = "0.000001";
-            var testExpression = new Expression(equation, CultureInfo.InvariantCulture);
+            var testExpression = Extensions.CreateExpression(equation);
             testExpression.Evaluate();
             Assert.Equal(equation, testExpression.ParsedExpression.ToString());
         }
@@ -181,18 +181,18 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleUnicode()
         {
-            Assert.Equal("経済協力開発機構", new Expression("'経済協力開発機構'", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal("Hello", new Expression(@"'\u0048\u0065\u006C\u006C\u006F'", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal("だ", new Expression(@"'\u3060'", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal("\u0100", new Expression(@"'\u0100'", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal("経済協力開発機構", Extensions.CreateExpression("'経済協力開発機構'").Evaluate());
+            Assert.Equal("Hello", Extensions.CreateExpression(@"'\u0048\u0065\u006C\u006C\u006F'").Evaluate());
+            Assert.Equal("だ", Extensions.CreateExpression(@"'\u3060'").Evaluate());
+            Assert.Equal("\u0100", Extensions.CreateExpression(@"'\u0100'").Evaluate());
         }
 
         [Fact]
         public void ShouldEscapeCharacters()
         {
-            Assert.Equal("'hello'", new Expression(@"'\'hello\''", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(" ' hel lo ' ", new Expression(@"' \' hel lo \' '", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal("hel\nlo", new Expression(@"'hel\nlo'", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal("'hello'", Extensions.CreateExpression(@"'\'hello\''").Evaluate());
+            Assert.Equal(" ' hel lo ' ", Extensions.CreateExpression(@"' \' hel lo \' '").Evaluate());
+            Assert.Equal("hel\nlo", Extensions.CreateExpression(@"'hel\nlo'").Evaluate());
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace NCalc.Tests
         {
             try
             {
-                new Expression("(3 + 2", CultureInfo.InvariantCulture).Evaluate();
+                Extensions.CreateExpression("(3 + 2").Evaluate();
                 throw new Exception();
             }
             catch (EvaluationException e)
@@ -212,30 +212,30 @@ namespace NCalc.Tests
         [Fact]
         public void Maths()
         {
-            Assert.Equal(1M, new Expression("Abs(-1)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(0d, new Expression("Acos(1)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(0d, new Expression("Asin(0)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(0d, new Expression("Atan(0)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(2d, new Expression("Ceiling(1.5)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(1d, new Expression("Cos(0)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(1d, new Expression("Exp(0)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(1d, new Expression("Floor(1.5)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(-1d, new Expression("IEEERemainder(3,2)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(0d, new Expression("Log(1,10)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(0d, new Expression("Log10(1)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(9d, new Expression("Pow(3,2)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(3.22d, new Expression("Round(3.222,2)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(-1, new Expression("Sign(-10)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(0d, new Expression("Sin(0)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(2d, new Expression("Sqrt(4)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(0d, new Expression("Tan(0)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(1d, new Expression("Truncate(1.7)", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal(1M, Extensions.CreateExpression("Abs(-1)").Evaluate());
+            Assert.Equal(0d, Extensions.CreateExpression("Acos(1)").Evaluate());
+            Assert.Equal(0d, Extensions.CreateExpression("Asin(0)").Evaluate());
+            Assert.Equal(0d, Extensions.CreateExpression("Atan(0)").Evaluate());
+            Assert.Equal(2d, Extensions.CreateExpression("Ceiling(1.5)").Evaluate());
+            Assert.Equal(1d, Extensions.CreateExpression("Cos(0)").Evaluate());
+            Assert.Equal(1d, Extensions.CreateExpression("Exp(0)").Evaluate());
+            Assert.Equal(1d, Extensions.CreateExpression("Floor(1.5)").Evaluate());
+            Assert.Equal(-1d, Extensions.CreateExpression("IEEERemainder(3,2)").Evaluate());
+            Assert.Equal(0d, Extensions.CreateExpression("Log(1,10)").Evaluate());
+            Assert.Equal(0d, Extensions.CreateExpression("Log10(1)").Evaluate());
+            Assert.Equal(9d, Extensions.CreateExpression("Pow(3,2)").Evaluate());
+            Assert.Equal(3.22d, Extensions.CreateExpression("Round(3.222,2)").Evaluate());
+            Assert.Equal(-1, Extensions.CreateExpression("Sign(-10)").Evaluate());
+            Assert.Equal(0d, Extensions.CreateExpression("Sin(0)").Evaluate());
+            Assert.Equal(2d, Extensions.CreateExpression("Sqrt(4)").Evaluate());
+            Assert.Equal(0d, Extensions.CreateExpression("Tan(0)").Evaluate());
+            Assert.Equal(1d, Extensions.CreateExpression("Truncate(1.7)").Evaluate());
         }
 
         [Fact]
         public void ExpressionShouldEvaluateCustomFunctions()
         {
-            var e = new Expression("SecretOperation(3, 6)", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("SecretOperation(3, 6)");
 
             e.EvaluateFunction += delegate (string name, FunctionArgs args)
                 {
@@ -249,7 +249,7 @@ namespace NCalc.Tests
         [Fact]
         public void ExpressionShouldEvaluateCustomFunctionsWithParameters()
         {
-            var e = new Expression("SecretOperation([e], 6) + f", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("SecretOperation([e], 6) + f");
             e.Parameters["e"] = 3;
             e.Parameters["f"] = 1;
 
@@ -265,9 +265,9 @@ namespace NCalc.Tests
         [Fact]
         public void ExpressionShouldEvaluateParameters()
         {
-            var e = new Expression("Round(Pow(Pi, 2) + Pow([Pi Squared], 2) + [X], 2)", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("Round(Pow(Pi, 2) + Pow([Pi Squared], 2) + [X], 2)");
 
-            e.Parameters["Pi Squared"] = new Expression("Pi * [Pi]", CultureInfo.InvariantCulture);
+            e.Parameters["Pi Squared"] = Extensions.CreateExpression("Pi * [Pi]");
             e.Parameters["X"] = 10;
 
             e.EvaluateParameter += delegate (string name, ParameterArgs args)
@@ -282,13 +282,13 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldEvaluateConditionnal()
         {
-            var eif = new Expression("if([divider] <> 0, [divided] / [divider], 0)", CultureInfo.InvariantCulture);
+            var eif = Extensions.CreateExpression("if([divider] <> 0, [divided] / [divider], 0)");
             eif.Parameters["divider"] = 5;
             eif.Parameters["divided"] = 5;
 
             Assert.Equal(1d, eif.Evaluate());
 
-            eif = new Expression("if([divider] <> 0, [divided] / [divider], 0)", CultureInfo.InvariantCulture);
+            eif = Extensions.CreateExpression("if([divider] <> 0, [divided] / [divider], 0)");
             eif.Parameters["divider"] = 0;
             eif.Parameters["divided"] = 5;
             Assert.Equal(0, eif.Evaluate());
@@ -297,7 +297,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldOverrideExistingFunctions()
         {
-            var e = new Expression("Round(1.99, 2)", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("Round(1.99, 2)");
 
             Assert.Equal(1.99d, e.Evaluate());
 
@@ -314,20 +314,20 @@ namespace NCalc.Tests
         public void ShouldEvaluateInOperator()
         {
             // The last argument should not be evaluated
-            var ein = new Expression("in((2 + 2), [1], [2], 1 + 2, 4, 1 / 0)", CultureInfo.InvariantCulture);
+            var ein = Extensions.CreateExpression("in((2 + 2), [1], [2], 1 + 2, 4, 1 / 0)");
             ein.Parameters["1"] = 2;
             ein.Parameters["2"] = 5;
 
             Assert.Equal((object)true, ein.Evaluate());
 
-            var eout = new Expression("in((2 + 2), [1], [2], 1 + 2, 3)", CultureInfo.InvariantCulture);
+            var eout = Extensions.CreateExpression("in((2 + 2), [1], [2], 1 + 2, 3)");
             eout.Parameters["1"] = 2;
             eout.Parameters["2"] = 5;
 
             Assert.Equal((object)false, eout.Evaluate());
 
             // Should work with strings
-            var estring = new Expression("in('to' + 'to', 'titi', 'toto')", CultureInfo.InvariantCulture);
+            var estring = Extensions.CreateExpression("in('to' + 'to', 'titi', 'toto')");
 
             Assert.Equal((object)true, estring.Evaluate());
 
@@ -371,7 +371,7 @@ namespace NCalc.Tests
 
             foreach (KeyValuePair<string, object> pair in expressions)
             {
-                Assert.Equal(pair.Value, new Expression(pair.Key, CultureInfo.InvariantCulture).Evaluate());
+                Assert.Equal(pair.Value, Extensions.CreateExpression(pair.Key).Evaluate());
             }
 
         }
@@ -379,19 +379,19 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleOperatorsPriority()
         {
-            Assert.Equal(8, new Expression("2+2+2+2", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(16, new Expression("2*2*2*2", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(6, new Expression("2*2+2", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(6, new Expression("2+2*2", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal(8, Extensions.CreateExpression("2+2+2+2").Evaluate());
+            Assert.Equal(16, Extensions.CreateExpression("2*2*2*2").Evaluate());
+            Assert.Equal(6, Extensions.CreateExpression("2*2+2").Evaluate());
+            Assert.Equal(6, Extensions.CreateExpression("2+2*2").Evaluate());
 
-            Assert.Equal(9d, new Expression("1 + 2 + 3 * 4 / 2", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(13.5, new Expression("18/2/2*3", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal(9d, Extensions.CreateExpression("1 + 2 + 3 * 4 / 2").Evaluate());
+            Assert.Equal(13.5, Extensions.CreateExpression("18/2/2*3").Evaluate());
         }
 
         [Fact]
         public void ShouldNotLoosePrecision()
         {
-            Assert.Equal(0.5, new Expression("3/6", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal(0.5, Extensions.CreateExpression("3/6").Evaluate());
         }
 
         [Fact]
@@ -399,7 +399,7 @@ namespace NCalc.Tests
         {
             try
             {
-                new Expression("4. + 2", CultureInfo.InvariantCulture).Evaluate();
+                Extensions.CreateExpression("4. + 2").Evaluate();
                 throw new Exception();
             }
             catch (EvaluationException e)
@@ -411,13 +411,13 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldNotRoundDecimalValues()
         {
-            Assert.Equal((object)false, new Expression("0 <= -0.6", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal((object)false, Extensions.CreateExpression("0 <= -0.6").Evaluate());
         }
 
         [Fact]
         public void ShouldEvaluateTernaryExpression()
         {
-            Assert.Equal(1, new Expression("1+2<3 ? 3+4 : 1", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal(1, Extensions.CreateExpression("1+2<3 ? 3+4 : 1").Evaluate());
         }
 
         [Fact]
@@ -455,21 +455,21 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleStringConcatenation()
         {
-            Assert.Equal("toto", new Expression("'to' + 'to'", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal("one2", new Expression("'one' + 2", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(3M, new Expression("1 + '2'", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal("toto", Extensions.CreateExpression("'to' + 'to'").Evaluate());
+            Assert.Equal("one2", Extensions.CreateExpression("'one' + 2").Evaluate());
+            Assert.Equal(3M, Extensions.CreateExpression("1 + '2'").Evaluate());
         }
 
         [Fact]
         public void ShouldDetectSyntaxErrorsBeforeEvaluation()
         {
-            var e = new Expression("a + b * (", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("a + b * (");
             Assert.Null(e.Error);
             Assert.True(e.HasErrors());
             Assert.True(e.HasErrors());
             Assert.NotNull(e.Error);
 
-            e = new Expression("+ b ", CultureInfo.InvariantCulture);
+            e = Extensions.CreateExpression("+ b ");
             Assert.Null(e.Error);
             Assert.True(e.HasErrors());
             Assert.NotNull(e.Error);
@@ -527,7 +527,7 @@ namespace NCalc.Tests
 
                 // Constructs a simple addition randomly. Odds are that the same expression gets constructed multiple times by different threads
                 var exp = n1 + " + " + n2;
-                var e = new Expression(exp, CultureInfo.InvariantCulture);
+                var e = Extensions.CreateExpression(exp);
                 Assert.True(e.Evaluate().Equals(n1 + n2));
             }
             catch (Exception e)
@@ -539,12 +539,12 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleCaseSensitiveness()
         {
-            Assert.Equal(1M, new Expression("aBs(-1)", EvaluateOptions.IgnoreCase, CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(1M, new Expression("Abs(-1)", EvaluateOptions.None, CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal(1M, Extensions.CreateExpression("aBs(-1)", EvaluateOptions.IgnoreCase).Evaluate());
+            Assert.Equal(1M, Extensions.CreateExpression("Abs(-1)", EvaluateOptions.None).Evaluate());
 
             try
             {
-                Assert.Equal(1M, new Expression("aBs(-1)", EvaluateOptions.None, CultureInfo.InvariantCulture).Evaluate());
+                Assert.Equal(1M, Extensions.CreateExpression("aBs(-1)", EvaluateOptions.None).Evaluate());
             }
             catch (ArgumentException)
             {
@@ -561,7 +561,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleCustomParametersWhenNoSpecificParameterIsDefined()
         {
-            var e = new Expression("Round(Pow([Pi], 2) + Pow([Pi], 2) + 10, 2)", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("Round(Pow([Pi], 2) + Pow([Pi], 2) + 10, 2)");
 
             e.EvaluateParameter += delegate (string name, ParameterArgs arg)
             {
@@ -575,7 +575,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleCustomFunctionsInFunctions()
         {
-            var e = new Expression("if(true, func1(x) + func2(func3(y)), 0)", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("if(true, func1(x) + func2(func3(y)), 0)");
 
             e.EvaluateFunction += delegate (string name, FunctionArgs arg)
             {
@@ -616,18 +616,18 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldParseScientificNotation()
         {
-            Assert.Equal(12.2d, new Expression("1.22e1", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(100d, new Expression("1e2", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(100d, new Expression("1e+2", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(0.01d, new Expression("1e-2", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(0.001d, new Expression(".1e-2", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(10000000000d, new Expression("1e10", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal(12.2d, Extensions.CreateExpression("1.22e1").Evaluate());
+            Assert.Equal(100d, Extensions.CreateExpression("1e2").Evaluate());
+            Assert.Equal(100d, Extensions.CreateExpression("1e+2").Evaluate());
+            Assert.Equal(0.01d, Extensions.CreateExpression("1e-2").Evaluate());
+            Assert.Equal(0.001d, Extensions.CreateExpression(".1e-2").Evaluate());
+            Assert.Equal(10000000000d, Extensions.CreateExpression("1e10").Evaluate());
         }
 
         [Fact]
         public void ShouldEvaluateArrayParameters()
         {
-            var e = new Expression("x * x", EvaluateOptions.IterateParameters, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("x * x", EvaluateOptions.IterateParameters);
             e.Parameters["x"] = new[] { 0, 1, 2, 3, 4 };
 
             var result = (IList)e.Evaluate();
@@ -642,7 +642,7 @@ namespace NCalc.Tests
         [Fact]
         public void CustomFunctionShouldReturnNull()
         {
-            var e = new Expression("SecretOperation(3, 6)", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("SecretOperation(3, 6)");
 
             e.EvaluateFunction += delegate (string name, FunctionArgs args)
             {
@@ -658,7 +658,7 @@ namespace NCalc.Tests
         [Fact]
         public void CustomParametersShouldReturnNull()
         {
-            var e = new Expression("x", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("x");
 
             e.EvaluateParameter += delegate (string name, ParameterArgs args)
             {
@@ -674,22 +674,22 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldCompareDates()
         {
-            Assert.Equal((object)true, new Expression("#1/1/2009#==#1/1/2009#", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal((object)false, new Expression("#2/1/2009#==#1/1/2009#", CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal((object)true, Extensions.CreateExpression("#1/1/2009#==#1/1/2009#").Evaluate());
+            Assert.Equal((object)false, Extensions.CreateExpression("#2/1/2009#==#1/1/2009#").Evaluate());
         }
 
         [Fact]
         public void ShouldRoundAwayFromZero()
         {
-            Assert.Equal(22d, new Expression("Round(22.5, 0)", CultureInfo.InvariantCulture).Evaluate());
-            Assert.Equal(23d, new Expression("Round(22.5, 0)", EvaluateOptions.RoundAwayFromZero, CultureInfo.InvariantCulture).Evaluate());
+            Assert.Equal(22d, Extensions.CreateExpression("Round(22.5, 0)").Evaluate());
+            Assert.Equal(23d, Extensions.CreateExpression("Round(22.5, 0)", EvaluateOptions.RoundAwayFromZero).Evaluate());
         }
 
         [Fact]
         public void ShouldEvaluateSubExpressions()
         {
-            var volume = new Expression("[surface] * h", CultureInfo.InvariantCulture);
-            var surface = new Expression("[l] * [L]", CultureInfo.InvariantCulture);
+            var volume = Extensions.CreateExpression("[surface] * h");
+            var surface = Extensions.CreateExpression("[l] * [L]");
             volume.Parameters["surface"] = surface;
             volume.Parameters["h"] = 3;
             surface.Parameters["l"] = 1;
@@ -701,21 +701,21 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleLongValues()
         {
-            var expression = new Expression("40000000000+1", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("40000000000+1");
             Assert.Equal(40000000000 + 1L, expression.Evaluate());
         }
 
         [Fact]
         public void ShouldCompareLongValues()
         {
-            var expression = new Expression("(0=1500000)||(((0+2200000000)-1500000)<0)", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("(0=1500000)||(((0+2200000000)-1500000)<0)");
             Assert.Equal((object)false, expression.Evaluate());
         }
 
         [Fact]
         public void ShouldDisplayErrorIfUncompatibleTypes()
         {
-            var e = new Expression("(a > b) + 10", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("(a > b) + 10");
             e.Parameters["a"] = 1;
             e.Parameters["b"] = 2;
             Assert.Throws<InvalidOperationException>(() => e.Evaluate());
@@ -732,10 +732,8 @@ namespace NCalc.Tests
         [InlineData("1-(X1 = 1)", 0)]
         public void ShouldOptionallyCalculateWithBoolean(string formula, object expectedValue)
         {
-            var expression = new Expression(formula, EvaluateOptions.BooleanCalculation, CultureInfo.InvariantCulture)
-            {
-                Parameters = { ["X1"] = 1 }
-            };
+            var expression = Extensions.CreateExpression(formula, EvaluateOptions.BooleanCalculation);
+            expression.Parameters["X1"] = 1;
 
             expression.Evaluate().Should().Be(expectedValue);
 
@@ -746,19 +744,19 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldNotConvertRealTypes()
         {
-            var e = new Expression("x/2", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("x/2");
             e.Parameters["x"] = 2F;
             Assert.Equal(typeof(float), e.Evaluate().GetType());
 
-            e = new Expression("x/2", CultureInfo.InvariantCulture);
+            e = Extensions.CreateExpression("x/2");
             e.Parameters["x"] = 2D;
             Assert.Equal(typeof(double), e.Evaluate().GetType());
 
-            e = new Expression("x/2", CultureInfo.InvariantCulture);
+            e = Extensions.CreateExpression("x/2");
             e.Parameters["x"] = 2m;
             Assert.Equal(typeof(decimal), e.Evaluate().GetType());
 
-            e = new Expression("a / b * 100", CultureInfo.InvariantCulture);
+            e = Extensions.CreateExpression("a / b * 100");
             e.Parameters["a"] = 20M;
             e.Parameters["b"] = 20M;
             Assert.Equal(100M, e.Evaluate());
@@ -768,7 +766,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldShortCircuitBooleanExpressions()
         {
-            var e = new Expression("([a] != 0) && ([b]/[a]>2)", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("([a] != 0) && ([b]/[a]>2)");
             e.Parameters["a"] = 0;
 
             Assert.Equal((object)false, e.Evaluate());
@@ -777,7 +775,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldAddDoubleAndDecimal()
         {
-            var e = new Expression("1.8 + Abs([var1])", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("1.8 + Abs([var1])");
             e.Parameters["var1"] = 9.2;
 
             Assert.Equal(11M, e.Evaluate());
@@ -786,7 +784,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldSubtractDoubleAndDecimal()
         {
-            var e = new Expression("[double] - [decimal]", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("[double] - [decimal]");
             e.Parameters["double"] = 2D;
             e.Parameters["decimal"] = 2m;
 
@@ -796,7 +794,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldMultiplyDoubleAndDecimal()
         {
-            var e = new Expression("[double] * [decimal]", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("[double] * [decimal]");
             e.Parameters["double"] = 2D;
             e.Parameters["decimal"] = 2m;
 
@@ -806,7 +804,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldDivideDoubleAndDecimal()
         {
-            var e = new Expression("[double] / [decimal]", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("[double] / [decimal]");
             e.Parameters["double"] = 2D;
             e.Parameters["decimal"] = 2m;
 
@@ -816,7 +814,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldModDoubleAndDecimal()
         {
-            var e = new Expression("[double] % [decimal]", CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression("[double] % [decimal]");
             e.Parameters["double"] = 2D;
             e.Parameters["decimal"] = 2m;
 
@@ -828,7 +826,7 @@ namespace NCalc.Tests
         [Theory]
         public void ShouldCheckPrecisionOfBothParametersForMaxAndMin(string expression, double expected)
         {
-            var e = new Expression(expression, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression(expression);
 
             var result = e.Evaluate();
 
@@ -842,7 +840,7 @@ namespace NCalc.Tests
         {
             const long expected = 9999999999L;
             var expression = $"if(true, {expected}, 0)";
-            var e = new Expression(expression, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression(expression);
 
             var actual = e.Evaluate();
 
@@ -857,23 +855,17 @@ namespace NCalc.Tests
             {
                 var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
                 culture.NumberFormat.NumberDecimalSeparator = ",";
-                Thread.CurrentThread.CurrentCulture = culture;
+                Thread.CurrentThread.CurrentCulture = culture;       
 
                 Assert.Throws<FormatException>(() =>
                 {
-                    var expr = new Expression("[a] < 2.0")
-                    {
-                        Parameters = { ["a"] = "1.7" }
-                    };
-
+                    var expr = Extensions.CreateExpression("[a] < 2.0");
+                    expr.Parameters["a"] = "1.7";
                     expr.Evaluate();
                 });
 
-                var e = new Expression("[a] < 2.0", CultureInfo.InvariantCulture)
-                {
-                    Parameters = { ["a"] = "1.7" }
-                };
-
+                var e = Extensions.CreateExpression("[a] < 2.0");
+                e.Parameters["a"] = "1.7";
                 Assert.Equal(true, e.Evaluate());
             }
             finally
@@ -902,44 +894,28 @@ namespace NCalc.Tests
             void ExecuteTest(string formula, object expectedValue)
             {
                 //Correctly evaluate with decimal dot culture and parameter with dot
-                Assert.Equal(expectedValue, new Expression(formula, cultureDot)
-                {
-                    Parameters = new Dictionary<string, object>
-                        {
-                            {"A","2.0"},
-                            {"B","0.5"}
-                        }
-                }.Evaluate());
-
+                var expression = Extensions.CreateExpression(formula, cultureDot);
+                expression.Parameters["A"] = "2.0";
+                expression.Parameters["B"] = "0.5";
+                Assert.Equal(expectedValue, expression.Evaluate());
+                
                 //Correctly evaluate with decimal comma and parameter with comma
-                Assert.Equal(expectedValue, new Expression(formula, cultureComma)
-                {
-                    Parameters = new Dictionary<string, object>
-                    {
-                        {"A","2.0"},
-                        {"B","0.5"}
-                    }
-                }.Evaluate());
+                expression = Extensions.CreateExpression(formula, cultureComma);
+                expression.Parameters["A"] = "2.0";
+                expression.Parameters["B"] = "0.5";
+                Assert.Equal(expectedValue, expression.Evaluate());
 
                 //combining decimal dot and comma fails
-                Assert.Throws<FormatException>(() => new Expression(formula, cultureComma)
-                {
-                    Parameters = new Dictionary<string, object>
-                    {
-                        {"A","2,0"},
-                        {"B","0.5"}
-                    }
-                }.Evaluate());
+                expression = Extensions.CreateExpression(formula, cultureComma);
+                expression.Parameters["A"] = "2,0";
+                expression.Parameters["B"] = "0.5";
+                Assert.Throws<FormatException>(() => expression.Evaluate());
 
                 //combining decimal dot and comma fails
-                Assert.Throws<FormatException>(() => new Expression(formula, cultureDot)
-                {
-                    Parameters = new Dictionary<string, object>
-                    {
-                        {"A","2,0"},
-                        {"B","0.5"}
-                    }
-                }.Evaluate());
+                expression = Extensions.CreateExpression(formula, cultureDot);
+                expression.Parameters["A"] = "2,0";
+                expression.Parameters["B"] = "0.5";
+                Assert.Throws<FormatException>(() => expression.Evaluate());
             }
         }
     }

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -881,6 +881,67 @@ namespace NCalc.Tests
                 Thread.CurrentThread.CurrentCulture = originalCulture;
             }
         }
+
+        [Fact]
+        public void ShouldCorrectlyParseCustomCultureParameter()
+        {
+            var cultureDot = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            cultureDot.NumberFormat.NumberGroupSeparator = " ";
+            var cultureComma = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            cultureComma.NumberFormat.CurrencyDecimalSeparator = ",";
+            cultureComma.NumberFormat.NumberGroupSeparator = " ";
+
+            //use 1*[A] to avoid evaluating expression parameters as string - force numeric conversion
+            ExecuteTest("1*[A]-[B]", 1.5m);
+            ExecuteTest("1*[A]+[B]", 2.5m);
+            ExecuteTest("1*[A]/[B]", 4m);
+            ExecuteTest("1*[A]*[B]", 1m);
+            ExecuteTest("1*[A]>[B]", true);
+            ExecuteTest("1*[A]<[B]", false);
+
+            void ExecuteTest(string formula, object expectedValue)
+            {
+                //Correctly evaluate with decimal dot culture and parameter with dot
+                Assert.Equal(expectedValue, new Expression(formula, cultureDot)
+                {
+                    Parameters = new Dictionary<string, object>
+                        {
+                            {"A","2.0"},
+                            {"B","0.5"}
+                        }
+                }.Evaluate());
+
+                //Correctly evaluate with decimal comma and parameter with comma
+                Assert.Equal(expectedValue, new Expression(formula, cultureComma)
+                {
+                    Parameters = new Dictionary<string, object>
+                    {
+                        {"A","2.0"},
+                        {"B","0.5"}
+                    }
+                }.Evaluate());
+
+                //combining decimal dot and comma fails
+                Assert.Throws<FormatException>(() => new Expression(formula, cultureComma)
+                {
+                    Parameters = new Dictionary<string, object>
+                    {
+                        {"A","2,0"},
+                        {"B","0.5"}
+                    }
+                }.Evaluate());
+
+                //combining decimal dot and comma fails
+                Assert.Throws<FormatException>(() => new Expression(formula, cultureDot)
+                {
+                    Parameters = new Dictionary<string, object>
+                    {
+                        {"A","2,0"},
+                        {"B","0.5"}
+                    }
+                }.Evaluate());
+            }
+        }
     }
 }
 

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -859,13 +859,11 @@ namespace NCalc.Tests
 
                 Assert.Throws<FormatException>(() =>
                 {
-                    var expr = Extensions.CreateExpression("[a] < 2.0");
-                    expr.Parameters["a"] = "1.7";
+                    var expr = new Expression("[a] < 2.0") { Parameters = { ["a"] = "1.7" } };
                     expr.Evaluate();
                 });
 
-                var e = Extensions.CreateExpression("[a] < 2.0");
-                e.Parameters["a"] = "1.7";
+                var e = new Expression("[a]<2.0", CultureInfo.InvariantCulture) { Parameters = { ["a"] = "1.7" } };
                 Assert.Equal(true, e.Evaluate());
             }
             finally

--- a/test/NCalc.Tests/Lambdas.cs
+++ b/test/NCalc.Tests/Lambdas.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Xunit;
 
 namespace NCalc.Tests
@@ -28,14 +29,16 @@ namespace NCalc.Tests
                 return a + b + c;
             }
 
-            public double Test(double a, double b, double c) 
+            public double Test(double a, double b, double c)
             {
                 return a + b + c;
             }
 
-            public string Sum(string msg, params int[] numbers) {
+            public string Sum(string msg, params int[] numbers)
+            {
                 int total = 0;
-                foreach (var num in numbers) {
+                foreach (var num in numbers)
+                {
                     total += num;
                 }
                 return msg + total;
@@ -44,7 +47,8 @@ namespace NCalc.Tests
             public int Sum(params int[] numbers)
             {
                 int total = 0;
-                foreach (var num in numbers) {
+                foreach (var num in numbers)
+                {
                     total += num;
                 }
                 return total;
@@ -70,11 +74,13 @@ namespace NCalc.Tests
                 return obj1.Count2 + obj2.Count2;
             }
 
-            public double Max(TestObject1 obj1, TestObject1 obj2) {
+            public double Max(TestObject1 obj1, TestObject1 obj2)
+            {
                 return Math.Max(obj1.Count1, obj2.Count1);
             }
 
-            public double Min(TestObject1 obj1, TestObject1 obj2) {
+            public double Min(TestObject1 obj1, TestObject1 obj2)
+            {
                 return Math.Min(obj1.Count1, obj2.Count1);
             }
 
@@ -100,24 +106,24 @@ namespace NCalc.Tests
             }
         }
 
-        private class SubContext : Context 
+        private class SubContext : Context
         {
-            public int Multiply(int a, int b) 
+            public int Multiply(int a, int b)
             {
                 return a * b;
             }
 
-            public new int Test(int a, int b) 
+            public new int Test(int a, int b)
             {
-                return base.Test(a,b) / 2;
+                return base.Test(a, b) / 2;
             }
 
-            public int Test(int a, int b, int c, int d) 
+            public int Test(int a, int b, int c, int d)
             {
                 return a + b + c + d;
             }
 
-            public int Sum(TestObject1 obj1, TestObject2 obj2, TestObject2 obj3) 
+            public int Sum(TestObject1 obj1, TestObject2 obj2, TestObject2 obj3)
             {
                 return obj1.Count1 + obj2.Count2 + obj3.Count2 + 100;
             }
@@ -131,7 +137,7 @@ namespace NCalc.Tests
         [InlineData("7%2", 1)]
         public void ShouldHandleIntegers(string input, int expected)
         {
-            var expression = new Expression(input);
+            var expression = new Expression(input, CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<int>();
 
             Assert.Equal(sut(), expected);
@@ -140,7 +146,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleParameters()
         {
-            var expression = new Expression("[FieldA] > 5 && [FieldB] = 'test'");
+            var expression = new Expression("[FieldA] > 5 && [FieldB] = 'test'", CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<Context, bool>();
             var context = new Context { FieldA = 7, FieldB = "test" };
 
@@ -150,7 +156,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleOverloadingSameParamCount()
         {
-            var expression = new Expression("Test('Hello', ' world!')");
+            var expression = new Expression("Test('Hello', ' world!')", CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<Context, string>();
             var context = new Context();
 
@@ -160,7 +166,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleOverloadingDifferentParamCount()
         {
-            var expression = new Expression("Test(Test(1, 2), 3, 4)");
+            var expression = new Expression("Test(Test(1, 2), 3, 4)", CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -170,7 +176,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleOverloadingObjectParameters()
         {
-            var expression = new Expression("Sum(CreateTestObject1(2), CreateTestObject2(2)) + Sum(CreateTestObject2(1), CreateTestObject1(5))");
+            var expression = new Expression("Sum(CreateTestObject1(2), CreateTestObject2(2)) + Sum(CreateTestObject2(1), CreateTestObject1(5))", CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -181,7 +187,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleParamsKeyword()
         {
-            var expression = new Expression("Sum(Test(1,1),2)");
+            var expression = new Expression("Sum(Test(1,1),2)", CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -189,8 +195,9 @@ namespace NCalc.Tests
         }
 
         [Fact]
-        public void ShouldHandleMixedParamsKeyword() {
-            var expression = new Expression("Sum('Your total is: ', Test(1,1), 2, 3)");
+        public void ShouldHandleMixedParamsKeyword()
+        {
+            var expression = new Expression("Sum('Your total is: ', Test(1,1), 2, 3)", CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<Context, string>();
             var context = new Context();
 
@@ -200,7 +207,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleCustomFunctions()
         {
-            var expression = new Expression("Test(Test(1, 2), 3)");
+            var expression = new Expression("Test(Test(1, 2), 3)", CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -210,11 +217,12 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleContextInheritance()
         {
-            var lambda1 = new Expression("Multiply(5, 2)").ToLambda<SubContext, int>();
-            var lambda2 = new Expression("Test(5, 5)").ToLambda<SubContext, int>();
-            var lambda3 = new Expression("Test(1,2,3,4)").ToLambda<SubContext, int>();
-            var lambda4 = new Expression("Sum(CreateTestObject1(100), CreateTestObject2(100), CreateTestObject2(100))").ToLambda<SubContext, int>();
-            
+            var lambda1 = new Expression("Multiply(5, 2)", CultureInfo.InvariantCulture).ToLambda<SubContext, int>();
+            var lambda2 = new Expression("Test(5, 5)", CultureInfo.InvariantCulture).ToLambda<SubContext, int>();
+            var lambda3 = new Expression("Test(1,2,3,4)", CultureInfo.InvariantCulture).ToLambda<SubContext, int>();
+            var lambda4 = new Expression("Sum(CreateTestObject1(100), CreateTestObject2(100), CreateTestObject2(100))", CultureInfo.InvariantCulture)
+                .ToLambda<SubContext, int>();
+
             var context = new SubContext();
             Assert.Equal(10, lambda1(context));
             Assert.Equal(5, lambda2(context));
@@ -226,8 +234,9 @@ namespace NCalc.Tests
         [InlineData("Test(1, 1, 1)")]
         [InlineData("Test(1.0, 1.0, 1.0)")]
         [InlineData("Test(1.0, 1, 1.0)")]
-        public void ShouldHandleImplicitConversion(string input) {
-            var lambda = new Expression(input).ToLambda<Context, int>();
+        public void ShouldHandleImplicitConversion(string input)
+        {
+            var lambda = new Expression(input, CultureInfo.InvariantCulture).ToLambda<Context, int>();
 
             var context = new Context();
             Assert.Equal(3, lambda(context));
@@ -236,7 +245,7 @@ namespace NCalc.Tests
         [Fact]
         public void MissingMethod()
         {
-            var expression = new Expression("MissingMethod(1)");
+            var expression = new Expression("MissingMethod(1)", CultureInfo.InvariantCulture);
             try
             {
                 var sut = expression.ToLambda<Context, int>();
@@ -255,7 +264,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleTernaryOperator()
         {
-            var expression = new Expression("Test(1, 2) = 3 ? 1 : 2");
+            var expression = new Expression("Test(1, 2) = 3 ? 1 : 2", CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -265,7 +274,7 @@ namespace NCalc.Tests
         [Fact]
         public void Issue1()
         {
-            var expr = new Expression("2 + 2 - a - b - x");
+            var expr = new Expression("2 + 2 - a - b - x", CultureInfo.InvariantCulture);
 
             decimal x = 5m;
             decimal a = 6m;
@@ -284,7 +293,7 @@ namespace NCalc.Tests
         [InlineData("in(3, 1, 2, 3, 4)")]
         public void ShouldHandleBuiltInFunctions(string input)
         {
-            var expression = new Expression(input);
+            var expression = new Expression(input, CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<bool>();
             Assert.True(sut());
         }
@@ -294,8 +303,9 @@ namespace NCalc.Tests
         [InlineData("Max(CreateTestObject1(1), CreateTestObject1(2))", 2)]
         [InlineData("Min(1, 2)", 1)]
         [InlineData("Max(1, 2)", 2)]
-        public void ShouldProritiseContextFunctions(string input, double expected) {
-            var expression = new Expression(input);
+        public void ShouldProritiseContextFunctions(string input, double expected)
+        {
+            var expression = new Expression(input, CultureInfo.InvariantCulture);
             var lambda = expression.ToLambda<Context, double>();
             var context = new Context();
             var actual = lambda(context);
@@ -310,7 +320,7 @@ namespace NCalc.Tests
         [InlineData("[FieldD] > 0", false)]
         public void ShouldHandleDataConversions(string input, bool expected)
         {
-            var expression = new Expression(input);
+            var expression = new Expression(input, CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<Context, bool>();
             var context = new Context { FieldA = 7, FieldB = "test", FieldC = 2.4m, FieldE = 2 };
 
@@ -318,14 +328,14 @@ namespace NCalc.Tests
         }
 
         [Theory]
-        [InlineData("Min(3,2)",2)]
+        [InlineData("Min(3,2)", 2)]
         [InlineData("Min(3.2,6.3)", 3.2)]
         [InlineData("Max(2.6,9.6)", 9.6)]
         [InlineData("Max(9,6)", 9.0)]
         [InlineData("Pow(5,2)", 25)]
         public void ShouldHandleNumericBuiltInFunctions(string input, double expected)
         {
-            var expression = new Expression(input);
+            var expression = new Expression(input, CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<object>();
             Assert.Equal(expected, sut());
         }
@@ -336,7 +346,7 @@ namespace NCalc.Tests
         [InlineData("if(true, 1.0, 0.0)", 1.0)]
         public void ShouldHandleFloatIfFunction(string input, double expected)
         {
-            var expression = new Expression(input);
+            var expression = new Expression(input, CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<object>();
             Assert.Equal(expected, sut());
         }
@@ -345,7 +355,7 @@ namespace NCalc.Tests
         [InlineData("if(true, 1, 0)", 1)]
         public void ShouldHandleIntIfFunction(string input, int expected)
         {
-            var expression = new Expression(input);
+            var expression = new Expression(input, CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<object>();
             Assert.Equal(expected, sut());
         }
@@ -354,7 +364,7 @@ namespace NCalc.Tests
         [InlineData("if(true, 'a', 'b')", "a")]
         public void ShouldHandleStringIfFunction(string input, string expected)
         {
-            var expression = new Expression(input);
+            var expression = new Expression(input, CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<object>();
             Assert.Equal(expected, sut());
         }
@@ -364,7 +374,7 @@ namespace NCalc.Tests
         {
             // Arrange
             const decimal expected = 6.908m;
-            var expression = new Expression("Foo * 3.14");
+            var expression = new Expression("Foo * 3.14", CultureInfo.InvariantCulture);
             var sut = expression.ToLambda<FooStruct, decimal>();
             var context = new FooStruct();
 
@@ -374,7 +384,7 @@ namespace NCalc.Tests
             // Assert
             Assert.Equal(expected, actual);
         }
-        
+
         // https://github.com/sklose/NCalc2/issues/54
         [Fact]
         public void Issue54()
@@ -382,7 +392,7 @@ namespace NCalc.Tests
             // Arrange
             const long expected = 9999999999L;
             var expression = $"if(true, {expected}, 0)";
-            var e = new Expression(expression);
+            var e = new Expression(expression, CultureInfo.InvariantCulture);
             var context = new object();
 
             var lambda = e.ToLambda<object, long>();

--- a/test/NCalc.Tests/Lambdas.cs
+++ b/test/NCalc.Tests/Lambdas.cs
@@ -137,7 +137,7 @@ namespace NCalc.Tests
         [InlineData("7%2", 1)]
         public void ShouldHandleIntegers(string input, int expected)
         {
-            var expression = new Expression(input, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(input);
             var sut = expression.ToLambda<int>();
 
             Assert.Equal(sut(), expected);
@@ -146,7 +146,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleParameters()
         {
-            var expression = new Expression("[FieldA] > 5 && [FieldB] = 'test'", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("[FieldA] > 5 && [FieldB] = 'test'");
             var sut = expression.ToLambda<Context, bool>();
             var context = new Context { FieldA = 7, FieldB = "test" };
 
@@ -156,7 +156,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleOverloadingSameParamCount()
         {
-            var expression = new Expression("Test('Hello', ' world!')", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("Test('Hello', ' world!')");
             var sut = expression.ToLambda<Context, string>();
             var context = new Context();
 
@@ -166,7 +166,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleOverloadingDifferentParamCount()
         {
-            var expression = new Expression("Test(Test(1, 2), 3, 4)", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("Test(Test(1, 2), 3, 4)");
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -176,7 +176,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleOverloadingObjectParameters()
         {
-            var expression = new Expression("Sum(CreateTestObject1(2), CreateTestObject2(2)) + Sum(CreateTestObject2(1), CreateTestObject1(5))", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("Sum(CreateTestObject1(2), CreateTestObject2(2)) + Sum(CreateTestObject2(1), CreateTestObject1(5))");
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -187,7 +187,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleParamsKeyword()
         {
-            var expression = new Expression("Sum(Test(1,1),2)", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("Sum(Test(1,1),2)");
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -197,7 +197,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleMixedParamsKeyword()
         {
-            var expression = new Expression("Sum('Your total is: ', Test(1,1), 2, 3)", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("Sum('Your total is: ', Test(1,1), 2, 3)");
             var sut = expression.ToLambda<Context, string>();
             var context = new Context();
 
@@ -207,7 +207,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleCustomFunctions()
         {
-            var expression = new Expression("Test(Test(1, 2), 3)", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("Test(Test(1, 2), 3)");
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -217,10 +217,10 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleContextInheritance()
         {
-            var lambda1 = new Expression("Multiply(5, 2)", CultureInfo.InvariantCulture).ToLambda<SubContext, int>();
-            var lambda2 = new Expression("Test(5, 5)", CultureInfo.InvariantCulture).ToLambda<SubContext, int>();
-            var lambda3 = new Expression("Test(1,2,3,4)", CultureInfo.InvariantCulture).ToLambda<SubContext, int>();
-            var lambda4 = new Expression("Sum(CreateTestObject1(100), CreateTestObject2(100), CreateTestObject2(100))", CultureInfo.InvariantCulture)
+            var lambda1 = Extensions.CreateExpression("Multiply(5, 2)").ToLambda<SubContext, int>();
+            var lambda2 = Extensions.CreateExpression("Test(5, 5)").ToLambda<SubContext, int>();
+            var lambda3 = Extensions.CreateExpression("Test(1,2,3,4)").ToLambda<SubContext, int>();
+            var lambda4 = Extensions.CreateExpression("Sum(CreateTestObject1(100), CreateTestObject2(100), CreateTestObject2(100))")
                 .ToLambda<SubContext, int>();
 
             var context = new SubContext();
@@ -236,7 +236,7 @@ namespace NCalc.Tests
         [InlineData("Test(1.0, 1, 1.0)")]
         public void ShouldHandleImplicitConversion(string input)
         {
-            var lambda = new Expression(input, CultureInfo.InvariantCulture).ToLambda<Context, int>();
+            var lambda = Extensions.CreateExpression(input).ToLambda<Context, int>();
 
             var context = new Context();
             Assert.Equal(3, lambda(context));
@@ -245,7 +245,7 @@ namespace NCalc.Tests
         [Fact]
         public void MissingMethod()
         {
-            var expression = new Expression("MissingMethod(1)", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("MissingMethod(1)");
             try
             {
                 var sut = expression.ToLambda<Context, int>();
@@ -264,7 +264,7 @@ namespace NCalc.Tests
         [Fact]
         public void ShouldHandleTernaryOperator()
         {
-            var expression = new Expression("Test(1, 2) = 3 ? 1 : 2", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("Test(1, 2) = 3 ? 1 : 2");
             var sut = expression.ToLambda<Context, int>();
             var context = new Context();
 
@@ -274,7 +274,7 @@ namespace NCalc.Tests
         [Fact]
         public void Issue1()
         {
-            var expr = new Expression("2 + 2 - a - b - x", CultureInfo.InvariantCulture);
+            var expr = Extensions.CreateExpression("2 + 2 - a - b - x");
 
             decimal x = 5m;
             decimal a = 6m;
@@ -293,7 +293,7 @@ namespace NCalc.Tests
         [InlineData("in(3, 1, 2, 3, 4)")]
         public void ShouldHandleBuiltInFunctions(string input)
         {
-            var expression = new Expression(input, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(input);
             var sut = expression.ToLambda<bool>();
             Assert.True(sut());
         }
@@ -305,7 +305,7 @@ namespace NCalc.Tests
         [InlineData("Max(1, 2)", 2)]
         public void ShouldProritiseContextFunctions(string input, double expected)
         {
-            var expression = new Expression(input, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(input);
             var lambda = expression.ToLambda<Context, double>();
             var context = new Context();
             var actual = lambda(context);
@@ -320,7 +320,7 @@ namespace NCalc.Tests
         [InlineData("[FieldD] > 0", false)]
         public void ShouldHandleDataConversions(string input, bool expected)
         {
-            var expression = new Expression(input, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(input);
             var sut = expression.ToLambda<Context, bool>();
             var context = new Context { FieldA = 7, FieldB = "test", FieldC = 2.4m, FieldE = 2 };
 
@@ -335,7 +335,7 @@ namespace NCalc.Tests
         [InlineData("Pow(5,2)", 25)]
         public void ShouldHandleNumericBuiltInFunctions(string input, double expected)
         {
-            var expression = new Expression(input, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(input);
             var sut = expression.ToLambda<object>();
             Assert.Equal(expected, sut());
         }
@@ -346,7 +346,7 @@ namespace NCalc.Tests
         [InlineData("if(true, 1.0, 0.0)", 1.0)]
         public void ShouldHandleFloatIfFunction(string input, double expected)
         {
-            var expression = new Expression(input, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(input);
             var sut = expression.ToLambda<object>();
             Assert.Equal(expected, sut());
         }
@@ -355,7 +355,7 @@ namespace NCalc.Tests
         [InlineData("if(true, 1, 0)", 1)]
         public void ShouldHandleIntIfFunction(string input, int expected)
         {
-            var expression = new Expression(input, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(input);
             var sut = expression.ToLambda<object>();
             Assert.Equal(expected, sut());
         }
@@ -364,7 +364,7 @@ namespace NCalc.Tests
         [InlineData("if(true, 'a', 'b')", "a")]
         public void ShouldHandleStringIfFunction(string input, string expected)
         {
-            var expression = new Expression(input, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(input);
             var sut = expression.ToLambda<object>();
             Assert.Equal(expected, sut());
         }
@@ -374,7 +374,7 @@ namespace NCalc.Tests
         {
             // Arrange
             const decimal expected = 6.908m;
-            var expression = new Expression("Foo * 3.14", CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression("Foo * 3.14");
             var sut = expression.ToLambda<FooStruct, decimal>();
             var context = new FooStruct();
 
@@ -392,7 +392,7 @@ namespace NCalc.Tests
             // Arrange
             const long expected = 9999999999L;
             var expression = $"if(true, {expected}, 0)";
-            var e = new Expression(expression, CultureInfo.InvariantCulture);
+            var e = Extensions.CreateExpression(expression);
             var context = new object();
 
             var lambda = e.ToLambda<object, long>();

--- a/test/NCalc.Tests/Performance.cs
+++ b/test/NCalc.Tests/Performance.cs
@@ -25,7 +25,7 @@ namespace NCalc.Tests
         [InlineData("5 * 2 = 2 * 5 && (1 / 3.0) * 3 = 1")]
         public void Arithmetics(string formula)
         {
-            var expression = new Expression(formula, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(formula);
             var lambda = expression.ToLambda<object>();
 
             var m1 = Measure(() => expression.Evaluate());
@@ -38,7 +38,7 @@ namespace NCalc.Tests
         [InlineData("[Param1] * 7 + [Param2]")]
         public void ParameterAccess(string formula)
         {
-            var expression = new Expression(formula, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(formula);
             var lambda = expression.ToLambda<Context, int>();
 
             var context = new Context { Param1 = 4, Param2 = 9 };
@@ -55,7 +55,7 @@ namespace NCalc.Tests
         [InlineData("[Param1] * 7 + [Param2]")]
         public void DynamicParameterAccess(string formula)
         {
-            var expression = new Expression(formula, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(formula);
             var lambda = expression.ToLambda<Context, int>();
 
             var context = new Context { Param1 = 4, Param2 = 9 };
@@ -75,7 +75,7 @@ namespace NCalc.Tests
         [InlineData("Foo([Param1] * 7, [Param2])")]
         public void FunctionWithDynamicParameterAccess(string formula)
         {
-            var expression = new Expression(formula, CultureInfo.InvariantCulture);
+            var expression = Extensions.CreateExpression(formula);
             var lambda = expression.ToLambda<Context, int>();
 
             var context = new Context { Param1 = 4, Param2 = 9 };

--- a/test/NCalc.Tests/Performance.cs
+++ b/test/NCalc.Tests/Performance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using Xunit;
 
 namespace NCalc.Tests
@@ -24,7 +25,7 @@ namespace NCalc.Tests
         [InlineData("5 * 2 = 2 * 5 && (1 / 3.0) * 3 = 1")]
         public void Arithmetics(string formula)
         {
-            var expression = new Expression(formula);
+            var expression = new Expression(formula, CultureInfo.InvariantCulture);
             var lambda = expression.ToLambda<object>();
 
             var m1 = Measure(() => expression.Evaluate());
@@ -37,10 +38,10 @@ namespace NCalc.Tests
         [InlineData("[Param1] * 7 + [Param2]")]
         public void ParameterAccess(string formula)
         {
-            var expression = new Expression(formula);
+            var expression = new Expression(formula, CultureInfo.InvariantCulture);
             var lambda = expression.ToLambda<Context, int>();
 
-            var context = new Context {Param1 = 4, Param2 = 9};
+            var context = new Context { Param1 = 4, Param2 = 9 };
             expression.Parameters["Param1"] = 4;
             expression.Parameters["Param2"] = 9;
 
@@ -54,7 +55,7 @@ namespace NCalc.Tests
         [InlineData("[Param1] * 7 + [Param2]")]
         public void DynamicParameterAccess(string formula)
         {
-            var expression = new Expression(formula);
+            var expression = new Expression(formula, CultureInfo.InvariantCulture);
             var lambda = expression.ToLambda<Context, int>();
 
             var context = new Context { Param1 = 4, Param2 = 9 };
@@ -74,7 +75,7 @@ namespace NCalc.Tests
         [InlineData("Foo([Param1] * 7, [Param2])")]
         public void FunctionWithDynamicParameterAccess(string formula)
         {
-            var expression = new Expression(formula);
+            var expression = new Expression(formula, CultureInfo.InvariantCulture);
             var lambda = expression.ToLambda<Context, int>();
 
             var context = new Context { Param1 = 4, Param2 = 9 };
@@ -88,7 +89,7 @@ namespace NCalc.Tests
                 if (name == "Foo")
                 {
                     var param = args.EvaluateParameters();
-                    args.Result = context.Foo((int) param[0], (int) param[1]);
+                    args.Result = context.Foo((int)param[0], (int)param[1]);
                 }
             };
 


### PR DESCRIPTION
This PR fixes some code analysis warnings and adds new constructor to Expression to allow passing the culture. Also some code cleanup. I've tried to avoid breaking changes, seems all should be fine.

Culture support was manually backported from [NCalc #46](https://github.com/ncalc/ncalc/pull/46) and [NCalc #52](https://github.com/ncalc/ncalc/pull/52)