### PR TITLE
Limit the frequency of cleaning the expression cache

### DIFF
--- a/NCalc.sln
+++ b/NCalc.sln
@@ -11,7 +11,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NCalc.Play", "src\NCalc.Pla
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{848BEACC-B4ED-420D-AA06-52167B60C2FA}"
 	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
 		grammer\NCalc.g = grammer\NCalc.g
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '3.0.{build}'
+version: '3.1.{build}'
 image: Visual Studio 2022
 configuration: Release
 branches:

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -1,4 +1,6 @@
-﻿using Antlr4.Runtime;
+﻿using System.Threading;
+
+using Antlr4.Runtime;
 using Antlr4.Runtime.Atn;
 using Antlr4.Runtime.Misc;
 using NCalc.Domain;
@@ -67,6 +69,8 @@ namespace NCalc
         private static bool _cacheEnabled = true;
         private static readonly ConcurrentDictionary<string, WeakReference<LogicalExpression>> _compiledExpressions =
             new ConcurrentDictionary<string, WeakReference<LogicalExpression>>();
+        internal static int CachedCompilations = 0;
+        private const int _cacheCleanInterval = 1000;
 
         public static bool CacheEnabled
         {
@@ -155,7 +159,10 @@ namespace NCalc
             {
                 _compiledExpressions[expression] = new WeakReference<LogicalExpression>(logicalExpression);
 
-                CleanCache();
+                if (Interlocked.Increment(ref CachedCompilations) % _cacheCleanInterval == 0)
+                {
+                    CleanCache();
+                }
                 //Debug.WriteLine("Expression added to cache: " + expression);
             }
 

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -69,8 +69,11 @@ namespace NCalc
         private static bool _cacheEnabled = true;
         private static readonly ConcurrentDictionary<string, WeakReference<LogicalExpression>> _compiledExpressions =
             new ConcurrentDictionary<string, WeakReference<LogicalExpression>>();
-        internal static int CachedCompilations = 0;
-        private const int _cacheCleanInterval = 1000;
+        internal static int CurrentCachedCompilations => _compiledExpressions.Count;
+
+        private static int _totalCachedCompilations = 0;
+        internal static int TotalCachedCompilations => _totalCachedCompilations;
+        public static int CacheCleanInterval { get; set; } = 1000;
 
         public static bool CacheEnabled
         {
@@ -86,6 +89,7 @@ namespace NCalc
                 }
             }
         }
+
 
         /// <summary>
         /// Removed unused entries from cached compiled expression
@@ -159,7 +163,7 @@ namespace NCalc
             {
                 _compiledExpressions[expression] = new WeakReference<LogicalExpression>(logicalExpression);
 
-                if (Interlocked.Increment(ref CachedCompilations) % _cacheCleanInterval == 0)
+                if (Interlocked.Increment(ref _totalCachedCompilations) % CacheCleanInterval == 0)
                 {
                     CleanCache();
                 }

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -204,12 +204,6 @@ namespace NCalc
 
         public LogicalExpression ParsedExpression { get; private set; }
 
-        [Obsolete("This property will be removed in the next minor update")]
-        protected Dictionary<string, IEnumerator> ParameterEnumerators;
-        
-        [Obsolete("This property will be removed in the next minor update")]
-        protected Dictionary<string, object> ParametersBackup;
-
         private struct Void { };
 
         public struct ExpressionWithParameter

--- a/src/NCalc/NCalc.csproj
+++ b/src/NCalc/NCalc.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<Description>This is a port of NCalc for .NET Core applications.</Description>
 		<AssemblyTitle>CoreCLR-NCalc</AssemblyTitle>
-		<VersionPrefix>3.0.0</VersionPrefix>
+		<VersionPrefix>3.1.0</VersionPrefix>
 		<Authors>Sebastian Klose</Authors>
 		<TargetFrameworks>net45;netstandard2.0;net6.0;net8.0</TargetFrameworks>
 		<AssemblyName>NCalc</AssemblyName>

--- a/src/NCalc/Properties/AssemblyInfo.cs
+++ b/src/NCalc/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // In SDK-style projects such as this one, several assembly attributes that were historically
@@ -18,3 +19,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("489d159b-9d5f-4726-97dd-b181db3eecc8")]
 
 [assembly: CLSCompliant(false)]
+
+[assembly: InternalsVisibleTo("NCalc.Tests")]

--- a/test/NCalc.Tests/Cache.cs
+++ b/test/NCalc.Tests/Cache.cs
@@ -1,0 +1,37 @@
+﻿using Xunit;
+
+namespace NCalc.Tests;
+public class Cache
+{
+    [Fact]
+    public void ShouldCacheWhenEnabled()
+    {
+        var startingCachedCompilations = Expression.CachedCompilations;
+
+        var expression = "123.33 + 33.123".CreateExpression(EvaluateOptions.None);
+        expression.Evaluate();
+
+        Assert.True(Expression.CachedCompilations > startingCachedCompilations);
+    }
+
+    [Fact]
+    public void ShouldNotCacheWhenNoCache()
+    {
+        var startingCachedCompilations = Expression.CachedCompilations;
+
+        var expression = "123.44 + 33.124".CreateExpression(EvaluateOptions.NoCache);
+        expression.Evaluate();
+
+        Assert.Equal(startingCachedCompilations, Expression.CachedCompilations);
+    }
+
+    [Fact]
+    public void ShouldCleanCache()
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            var expression = $"123.44 + {i}".CreateExpression();
+            expression.Evaluate();
+        }
+    }
+}

--- a/test/NCalc.Tests/Cache.cs
+++ b/test/NCalc.Tests/Cache.cs
@@ -1,37 +1,40 @@
 ﻿using Xunit;
 
 namespace NCalc.Tests;
+
 public class Cache
 {
     [Fact]
     public void ShouldCacheWhenEnabled()
     {
-        var startingCachedCompilations = Expression.CachedCompilations;
+        var startingCachedCompilations = Expression.TotalCachedCompilations;
 
         var expression = "123.33 + 33.123".CreateExpression(EvaluateOptions.None);
         expression.Evaluate();
 
-        Assert.True(Expression.CachedCompilations > startingCachedCompilations);
+        Assert.True(Expression.TotalCachedCompilations > startingCachedCompilations);
     }
 
     [Fact]
     public void ShouldNotCacheWhenNoCache()
     {
-        var startingCachedCompilations = Expression.CachedCompilations;
+        var startingCachedCompilations = Expression.TotalCachedCompilations;
 
         var expression = "123.44 + 33.124".CreateExpression(EvaluateOptions.NoCache);
         expression.Evaluate();
 
-        Assert.Equal(startingCachedCompilations, Expression.CachedCompilations);
+        Assert.Equal(startingCachedCompilations, Expression.TotalCachedCompilations);
     }
 
     [Fact]
     public void ShouldCleanCache()
     {
-        for (int i = 0; i < 1000; i++)
+        var cacheCleanInterval = Expression.CacheCleanInterval;
+        for (int i = 0; i < cacheCleanInterval; i++)
         {
-            var expression = $"123.44 + {i}".CreateExpression();
-            expression.Evaluate();
+            $"123.44 + {i}"
+                .CreateExpression()
+                .Evaluate();
         }
     }
 }

--- a/test/NCalc.Tests/Extensions.cs
+++ b/test/NCalc.Tests/Extensions.cs
@@ -4,10 +4,10 @@ namespace NCalc.Tests
 {
     internal static class Extensions
     {
-        internal static Expression CreateExpression(string expression, CultureInfo? cultureInfo = null) =>
+        internal static Expression CreateExpression(this string expression, CultureInfo? cultureInfo = null) =>
            new Expression(expression, cultureInfo ?? CultureInfo.InvariantCulture);
 
-        internal static Expression CreateExpression(string expression, EvaluateOptions evaluateOptions, CultureInfo? cultureInfo = null) =>
+        internal static Expression CreateExpression(this string expression, EvaluateOptions evaluateOptions, CultureInfo? cultureInfo = null) =>
            new Expression(expression, evaluateOptions, cultureInfo ?? CultureInfo.InvariantCulture);
     }
 }

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -11,6 +11,8 @@ using Xunit.Abstractions;
 
 namespace NCalc.Tests
 {
+
+    [Collection("Expression")]
     public class Fixtures
     {
         private readonly ITestOutputHelper _output;

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -11,8 +11,6 @@ using Xunit.Abstractions;
 
 namespace NCalc.Tests
 {
-
-    [Collection("Expression")]
     public class Fixtures
     {
         private readonly ITestOutputHelper _output;

--- a/test/NCalc.Tests/Lambdas.cs
+++ b/test/NCalc.Tests/Lambdas.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace NCalc.Tests
 {
+    [Collection("Expression")]
     public class Lambdas
     {
         private class Context

--- a/test/NCalc.Tests/Lambdas.cs
+++ b/test/NCalc.Tests/Lambdas.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Globalization;
 using Xunit;
 
 namespace NCalc.Tests
 {
-    [Collection("Expression")]
     public class Lambdas
     {
         private class Context

--- a/test/NCalc.Tests/Lambdas.cs
+++ b/test/NCalc.Tests/Lambdas.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace NCalc.Tests

--- a/test/NCalc.Tests/NCalc.Tests.csproj
+++ b/test/NCalc.Tests/NCalc.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>

--- a/test/NCalc.Tests/Performance.cs
+++ b/test/NCalc.Tests/Performance.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Globalization;
 using Xunit;
 
 namespace NCalc.Tests
 {
-    [Collection("Expression")]
     public class Performance
     {
         private const int Iterations = 100000;

--- a/test/NCalc.Tests/Performance.cs
+++ b/test/NCalc.Tests/Performance.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace NCalc.Tests
 {
+    [Collection("Expression")]
     public class Performance
     {
         private const int Iterations = 100000;


### PR DESCRIPTION
#101 illustrated the complexity of caching.  Rather than overhaul caching, this PR limits the clean frequency to every 1000 new compilations.