### PR TITLE
Add PackageLicenseExpression for the NuGet package

### DIFF
--- a/src/NCalc/NCalc.csproj
+++ b/src/NCalc/NCalc.csproj
@@ -10,6 +10,7 @@
 		<PackageId>CoreCLR-NCalc</PackageId>
 		<PackageTags>ncalc;coreclr;expression;evaluator</PackageTags>
 		<PackageProjectUrl>https://github.com/sklose/NCalc2</PackageProjectUrl>
+                <PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>git://github.com/sklose/NCalc2</RepositoryUrl>
 		<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>


### PR DESCRIPTION
https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices#licensing

It is recommended to use the `PackageLicenseExpression`.